### PR TITLE
Implement persistent sidebar via content script

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,22 @@
+(() => {
+  if (document.getElementById('omora-sidebar')) return;
+
+  const sidebar = document.createElement('iframe');
+  sidebar.id = 'omora-sidebar';
+  sidebar.src = chrome.runtime.getURL('sidebar.html');
+  Object.assign(sidebar.style, {
+    position: 'fixed',
+    top: '0',
+    right: '0',
+    width: '400px',
+    height: '100vh',
+    border: 'none',
+    borderLeft: '1px solid #ccc',
+    boxShadow: '0 0 8px rgba(0,0,0,0.15)',
+    zIndex: '2147483647',
+    background: 'white'
+  });
+
+  document.body.style.marginRight = '400px';
+  document.body.appendChild(sidebar);
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,19 @@
     "version": "0.1",
     "description": "A quiet, elegant browser sidebar for bookmarks, tasks & maybe AI.",
     "permissions": ["sidePanel"],
+    "content_scripts": [
+      {
+        "matches": ["<all_urls>"],
+        "js": ["content.js"],
+        "run_at": "document_idle"
+      }
+    ],
+    "web_accessible_resources": [
+      {
+        "resources": ["sidebar.html"],
+        "matches": ["<all_urls>"]
+      }
+    ],
     "side_panel": {
       "default_path": "src/sidebar.html"
     },

--- a/sidebar.html
+++ b/sidebar.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Omora Sidebar</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 16px;
+    }
+  </style>
+</head>
+<body>
+  <p>Omora Sidebar Ready</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- inject sidebar iframe into every page with content script
- expose sidebar.html as web accessible and add manifest entries
- provide simple sidebar markup with readiness message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e599c2748329a821caa4fff02104