### PR TITLE
Add toolbar action to toggle sidebar

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,5 @@
+chrome.action.onClicked.addListener((tab) => {
+  if (tab.id !== undefined) {
+    chrome.tabs.sendMessage(tab.id, { type: 'toggle-sidebar' });
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,22 +1,47 @@
 (() => {
-  if (document.getElementById('omora-sidebar')) return;
+  let sidebar = document.getElementById('omora-sidebar');
+  let sidebarVisible = true;
 
-  const sidebar = document.createElement('iframe');
-  sidebar.id = 'omora-sidebar';
-  sidebar.src = chrome.runtime.getURL('sidebar.html');
-  Object.assign(sidebar.style, {
-    position: 'fixed',
-    top: '0',
-    right: '0',
-    width: '400px',
-    height: '100vh',
-    border: 'none',
-    borderLeft: '1px solid #ccc',
-    boxShadow: '0 0 8px rgba(0,0,0,0.15)',
-    zIndex: '2147483647',
-    background: 'white'
+  if (!sidebar) {
+    sidebar = document.createElement('iframe');
+    sidebar.id = 'omora-sidebar';
+    sidebar.src = chrome.runtime.getURL('sidebar.html');
+    Object.assign(sidebar.style, {
+      position: 'fixed',
+      top: '0',
+      right: '0',
+      width: '400px',
+      height: '100vh',
+      border: 'none',
+      borderLeft: '1px solid #ccc',
+      boxShadow: '0 0 8px rgba(0,0,0,0.15)',
+      zIndex: '2147483647',
+      background: 'white'
+    });
+    document.body.appendChild(sidebar);
+  }
+
+  const showSidebar = () => {
+    sidebar.style.display = 'block';
+    document.body.style.marginRight = '400px';
+    sidebarVisible = true;
+  };
+
+  const hideSidebar = () => {
+    sidebar.style.display = 'none';
+    document.body.style.marginRight = '0px';
+    sidebarVisible = false;
+  };
+
+  const toggleSidebar = () => {
+    sidebarVisible ? hideSidebar() : showSidebar();
+  };
+
+  showSidebar();
+
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message && message.type === 'toggle-sidebar') {
+      toggleSidebar();
+    }
   });
-
-  document.body.style.marginRight = '400px';
-  document.body.appendChild(sidebar);
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
         "run_at": "document_idle"
       }
     ],
-    "web_accessible_resources": [
+      "web_accessible_resources": [
       {
         "resources": ["sidebar.html"],
         "matches": ["<all_urls>"]
@@ -19,6 +19,9 @@
     ],
     "side_panel": {
       "default_path": "src/sidebar.html"
+    },
+    "background": {
+      "service_worker": "background.js"
     },
     "action": {
       "default_title": "Omora",


### PR DESCRIPTION
## Summary
- add background service worker that relays toolbar clicks to content scripts
- handle toggle messages in content script, showing or hiding the sidebar
- register action and service worker in the manifest

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e75b02488329b56f954355eebf43