### PR TITLE
feat: add keyboard shortcut to toggle sidebar

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,3 +3,18 @@ chrome.action.onClicked.addListener((tab) => {
     chrome.tabs.sendMessage(tab.id, { type: 'toggle-sidebar' });
   }
 });
+
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle-sidebar') {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const activeTab = tabs[0];
+      if (activeTab?.id !== undefined) {
+        chrome.tabs.sendMessage(activeTab.id, { type: 'toggle-sidebar' }, () => {
+          if (chrome.runtime.lastError) {
+            // No matching content script; ignore.
+          }
+        });
+      }
+    });
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,14 @@
         "32": "public/icon.ico"
       }
     },
+    "commands": {
+      "toggle-sidebar": {
+        "suggested_key": {
+          "default": "Ctrl+Shift+O"
+        },
+        "description": "Toggle the Omora sidebar"
+      }
+    },
     "icons": {
       "128": "public/icon.png"
     }


### PR DESCRIPTION
## Summary
- add manifest command for toggling Omora sidebar with `Ctrl+Shift+O`
- handle `chrome.commands` in background service worker to message active tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891e8bac8b4832995b40026c0c03ea4