### PR TITLE
feat: add sidebar hide toggle

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,7 @@
 (() => {
   let sidebar = document.getElementById('omora-sidebar');
   let sidebarVisible = true;
+  let toggleButton = document.getElementById('omora-toggle-button');
 
   if (!sidebar) {
     sidebar = document.createElement('iframe');
@@ -25,19 +26,49 @@
     sidebar.style.display = 'block';
     document.body.style.marginRight = '400px';
     sidebarVisible = true;
+    toggleButton.style.display = 'none';
   };
 
   const hideSidebar = () => {
     sidebar.style.display = 'none';
     document.body.style.marginRight = '0px';
     sidebarVisible = false;
+    toggleButton.style.display = 'block';
   };
 
   const toggleSidebar = () => {
     sidebarVisible ? hideSidebar() : showSidebar();
   };
 
+  if (!toggleButton) {
+    toggleButton = document.createElement('button');
+    toggleButton.id = 'omora-toggle-button';
+    toggleButton.textContent = 'Omora';
+    Object.assign(toggleButton.style, {
+      position: 'fixed',
+      top: '50%',
+      right: '0',
+      transform: 'translateY(-50%)',
+      zIndex: '2147483647',
+      display: 'none',
+      padding: '8px 4px',
+      cursor: 'pointer',
+      background: '#fff',
+      border: '1px solid #ccc',
+      borderRight: 'none',
+      borderRadius: '4px 0 0 4px'
+    });
+    toggleButton.addEventListener('click', showSidebar);
+    document.body.appendChild(toggleButton);
+  }
+
   showSidebar();
+
+  window.addEventListener('message', (event) => {
+    if (event.data && event.data.type === 'hide-sidebar') {
+      hideSidebar();
+    }
+  });
 
   chrome.runtime.onMessage.addListener((message) => {
     if (message && message.type === 'toggle-sidebar') {

--- a/sidebar.html
+++ b/sidebar.html
@@ -8,10 +8,28 @@
       font-family: Arial, sans-serif;
       margin: 0;
       padding: 16px;
+      position: relative;
+    }
+
+    #hide-sidebar-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      background: transparent;
+      border: none;
+      font-size: 16px;
+      cursor: pointer;
     }
   </style>
 </head>
 <body>
+  <button id="hide-sidebar-btn" title="Hide">×</button>
   <p>Omora Sidebar Ready</p>
+
+  <script>
+    document.getElementById('hide-sidebar-btn').addEventListener('click', () => {
+      parent.postMessage({ type: 'hide-sidebar' }, '*');
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hide button inside sidebar iframe that posts a `hide-sidebar` message
- handle hide message in content script and show a floating toggle button to reopen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891eab9eac48329b9bba386b838e6de