### PR TITLE
Fix sidebar CSP by moving inline script to external file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,7 @@
     ],
       "web_accessible_resources": [
       {
-        "resources": ["sidebar.html"],
+        "resources": ["sidebar.html", "sidebar.js"],
         "matches": ["<all_urls>"]
       }
     ],

--- a/sidebar.html
+++ b/sidebar.html
@@ -26,10 +26,6 @@
   <button id="hide-sidebar-btn" title="Hide">×</button>
   <p>Omora Sidebar Ready</p>
 
-  <script>
-    document.getElementById('hide-sidebar-btn').addEventListener('click', () => {
-      parent.postMessage({ type: 'hide-sidebar' }, '*');
-    });
-  </script>
+  <script src="sidebar.js"></script>
 </body>
 </html>

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const hideButton = document.getElementById('hide-sidebar-btn');
+  if (hideButton) {
+    hideButton.addEventListener('click', () => {
+      parent.postMessage({ type: 'hide-sidebar' }, '*');
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- move inline sidebar script into `sidebar.js`
- expose `sidebar.html` and `sidebar.js` via `web_accessible_resources`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f197c8f4832995ace6bc38e765a1