### PR TITLE
Add custom new tab page with bookmarks and clock

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,13 +27,15 @@
       "suggested_key": {
         "default": "Ctrl+Shift+O"
       },
-      "description": "Toggle the Omora sidebar"
+      "description": "Toggle the Omora sidebar",
     }
+  },
+  "chrome_url_overrides": {
+    "newtab": "newtab.html"
   },
   "icons": {
     "16": "public/icon16.png",
     "32": "public/icon32.png",
-    "128": "public/icon128.png"
+    "128": "public/icon128.png",
   }
 }
-

--- a/newtab.css
+++ b/newtab.css
@@ -1,0 +1,44 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+  background: #f5f5f5;
+  color: #333;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+}
+
+.container {
+  text-align: center;
+  width: 100%;
+  max-width: 800px;
+  padding: 20px;
+}
+
+#clock {
+  font-size: 64px;
+  margin-bottom: 40px;
+}
+
+.bookmarks {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 20px;
+}
+
+.tile {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-decoration: none;
+  color: #333;
+  font-size: 16px;
+  transition: background 0.3s;
+}
+
+.tile:hover {
+  background: #e0e0e0;
+}

--- a/newtab.html
+++ b/newtab.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Omora New Tab</title>
+  <link rel="stylesheet" href="newtab.css" />
+</head>
+<body>
+  <div class="container">
+    <div id="clock"></div>
+    <div class="bookmarks">
+      <a class="tile" href="https://www.google.com" target="_blank" rel="noopener noreferrer">Google</a>
+      <a class="tile" href="https://www.youtube.com" target="_blank" rel="noopener noreferrer">YouTube</a>
+      <a class="tile" href="https://www.reddit.com" target="_blank" rel="noopener noreferrer">Reddit</a>
+      <a class="tile" href="https://news.ycombinator.com" target="_blank" rel="noopener noreferrer">Hacker News</a>
+      <a class="tile" href="https://github.com" target="_blank" rel="noopener noreferrer">GitHub</a>
+    </div>
+  </div>
+  <script src="newtab.js"></script>
+</body>
+</html>

--- a/newtab.js
+++ b/newtab.js
@@ -1,0 +1,12 @@
+function updateClock() {
+  const clock = document.getElementById('clock');
+  const now = new Date();
+  const hours = String(now.getHours()).padStart(2, '0');
+  const minutes = String(now.getMinutes()).padStart(2, '0');
+  clock.textContent = `${hours}:${minutes}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  updateClock();
+  setInterval(updateClock, 1000);
+});


### PR DESCRIPTION
## Summary
- Implement `newtab.html` landing page with live clock and bookmarks tiles
- Add responsive styling and update logic via `newtab.css` and `newtab.js`
- Configure extension to override Chrome's new tab page in `manifest.json`

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f68154b483299e08de75c90cf29d