### PR TITLE
Add settings button to sidebar

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Settings</title>
+</head>
+<body>
+  <h1>Settings</h1>
+  <p>Settings page placeholder.</p>
+</body>
+</html>

--- a/sidebar.css
+++ b/sidebar.css
@@ -1,0 +1,34 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 16px;
+  position: relative;
+  padding-bottom: 60px; /* space for settings button */
+}
+
+#hide-sidebar-btn {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+#settings-btn {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  background-color: #f1f1f1;
+  border: none;
+  border-top: 1px solid #ccc;
+  padding: 10px;
+  font-size: 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}

--- a/sidebar.html
+++ b/sidebar.html
@@ -3,28 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <title>Omora Sidebar</title>
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      margin: 0;
-      padding: 16px;
-      position: relative;
-    }
-
-    #hide-sidebar-btn {
-      position: absolute;
-      top: 8px;
-      right: 8px;
-      background: transparent;
-      border: none;
-      font-size: 16px;
-      cursor: pointer;
-    }
-  </style>
+  <link rel="stylesheet" href="sidebar.css" />
 </head>
 <body>
   <button id="hide-sidebar-btn" title="Hide">×</button>
   <p>Omora Sidebar Ready</p>
+
+  <button id="settings-btn"><span aria-hidden="true">⚙️</span> Settings</button>
 
   <script src="sidebar.js"></script>
 </body>

--- a/sidebar.js
+++ b/sidebar.js
@@ -5,4 +5,11 @@ document.addEventListener('DOMContentLoaded', () => {
       parent.postMessage({ type: 'hide-sidebar' }, '*');
     });
   }
+
+  const settingsButton = document.getElementById('settings-btn');
+  if (settingsButton) {
+    settingsButton.addEventListener('click', () => {
+      chrome.tabs.create({ url: chrome.runtime.getURL('settings.html') });
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Add bottom-fixed Settings button to sidebar with gear icon.
- Style sidebar via new sidebar.css for persistent button placement.
- Open internal settings.html page in new tab when Settings button is clicked.

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f7cebdfc832995b884ef05684987