### PR TITLE
Add light/dark theme toggle for sidebar

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -6,6 +6,11 @@
 </head>
 <body>
   <h1>Settings</h1>
-  <p>Settings page placeholder.</p>
+  <label>
+    <input type="checkbox" id="theme-toggle" />
+    Dark Mode
+  </label>
+
+  <script src="settings.js"></script>
 </body>
 </html>

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,14 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+
+  chrome.storage.local.get('sidebarTheme', ({ sidebarTheme }) => {
+    toggle.checked = sidebarTheme === 'dark';
+  });
+
+  toggle.addEventListener('change', () => {
+    const theme = toggle.checked ? 'dark' : 'light';
+    chrome.storage.local.set({ sidebarTheme: theme });
+  });
+});
+

--- a/sidebar.css
+++ b/sidebar.css
@@ -21,9 +21,7 @@ body {
   bottom: 0;
   left: 0;
   width: 100%;
-  background-color: #f1f1f1;
   border: none;
-  border-top: 1px solid #ccc;
   padding: 10px;
   font-size: 16px;
   cursor: pointer;
@@ -31,4 +29,34 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
+}
+
+.light-theme {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+.light-theme #settings-btn {
+  background-color: #f1f1f1;
+  border-top: 1px solid #ccc;
+  color: #000000;
+}
+
+.light-theme #hide-sidebar-btn {
+  color: #000000;
+}
+
+.dark-theme {
+  background-color: #1e1e1e;
+  color: #f1f1f1;
+}
+
+.dark-theme #settings-btn {
+  background-color: #333333;
+  border-top: 1px solid #555555;
+  color: #f1f1f1;
+}
+
+.dark-theme #hide-sidebar-btn {
+  color: #f1f1f1;
 }

--- a/sidebar.html
+++ b/sidebar.html
@@ -5,7 +5,7 @@
   <title>Omora Sidebar</title>
   <link rel="stylesheet" href="sidebar.css" />
 </head>
-<body>
+<body class="light-theme">
   <button id="hide-sidebar-btn" title="Hide">×</button>
   <p>Omora Sidebar Ready</p>
 

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,4 +1,20 @@
+function applyTheme(theme) {
+  const body = document.body;
+  body.classList.remove('light-theme', 'dark-theme');
+  body.classList.add(theme === 'dark' ? 'dark-theme' : 'light-theme');
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  chrome.storage.local.get('sidebarTheme', ({ sidebarTheme }) => {
+    applyTheme(sidebarTheme || 'light');
+  });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes.sidebarTheme) {
+      applyTheme(changes.sidebarTheme.newValue || 'light');
+    }
+  });
+
   const hideButton = document.getElementById('hide-sidebar-btn');
   if (hideButton) {
     hideButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add a theme toggle on the settings page and persist the selection
- style sidebar for light and dark modes and load theme from storage
- update sidebar immediately when the stored theme changes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891f90ff4e4832982e8f39e56d68bb7