### PR TITLE
feat: persistent sidebar modes

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,22 +1,51 @@
-chrome.action.onClicked.addListener((tab) => {
-  if (tab.id !== undefined) {
-    chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      files: ['content.js'],
-    });
-  }
+function broadcastState() {
+  chrome.storage.local.get(
+    ['sidebarVisible', 'sidebarExpanded'],
+    ({ sidebarVisible, sidebarExpanded }) => {
+      const message = {
+        type: 'apply-sidebar-state',
+        visible: sidebarVisible !== false,
+        expanded: sidebarExpanded === true,
+      };
+      chrome.tabs.query({}, (tabs) => {
+        tabs.forEach((tab) => {
+          if (tab.id !== undefined) {
+            chrome.tabs.sendMessage(tab.id, message);
+          }
+        });
+      });
+    },
+  );
+}
+
+chrome.action.onClicked.addListener(() => {
+  chrome.storage.local.get('sidebarVisible', ({ sidebarVisible }) => {
+    chrome.storage.local.set({ sidebarVisible: !(sidebarVisible !== false) });
+  });
 });
 
 chrome.commands.onCommand.addListener((command) => {
   if (command === 'toggle-sidebar') {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const activeTab = tabs[0];
-      if (activeTab?.id !== undefined) {
-        chrome.scripting.executeScript({
-          target: { tabId: activeTab.id },
-          files: ['content.js'],
-        });
-      }
+    chrome.storage.local.get('sidebarVisible', ({ sidebarVisible }) => {
+      chrome.storage.local.set({ sidebarVisible: !(sidebarVisible !== false) });
     });
   }
 });
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === 'hide-sidebar') {
+    chrome.storage.local.set({ sidebarVisible: false });
+  }
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && (changes.sidebarVisible || changes.sidebarExpanded)) {
+    broadcastState();
+  }
+});
+
+chrome.runtime.onStartup.addListener(broadcastState);
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.storage.local.set({ sidebarVisible: true, sidebarExpanded: false }, broadcastState);
+});
+

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
       "128": "public/icon128.png"
     }
   },
-  "permissions": ["scripting", "activeTab"],
+  "permissions": ["scripting", "activeTab", "storage"],
   "host_permissions": ["<all_urls>"],
   "web_accessible_resources": [
     {
@@ -30,6 +30,13 @@
       "description": "Toggle the Omora sidebar",
     }
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
   "chrome_url_overrides": {
     "newtab": "newtab.html"
   },

--- a/newtab.html
+++ b/newtab.html
@@ -17,6 +17,7 @@
       <a class="tile" href="https://github.com" target="_blank" rel="noopener noreferrer">GitHub</a>
     </div>
   </div>
+  <script src="content.js"></script>
   <script src="newtab.js"></script>
 </body>
 </html>

--- a/sidebar.css
+++ b/sidebar.css
@@ -6,10 +6,28 @@ body {
   padding-bottom: 60px; /* space for settings button */
 }
 
+.collapsed {
+  width: 60px;
+}
+
+.expanded {
+  width: 250px;
+}
+
 #hide-sidebar-btn {
   position: absolute;
   top: 8px;
   right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+#toggle-expand-btn {
+  position: absolute;
+  top: 8px;
+  left: 8px;
   background: transparent;
   border: none;
   font-size: 16px;
@@ -29,6 +47,14 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
+}
+
+.collapsed #settings-btn .label {
+  display: none;
+}
+
+.collapsed #settings-btn {
+  justify-content: center;
 }
 
 .light-theme {

--- a/sidebar.html
+++ b/sidebar.html
@@ -5,11 +5,15 @@
   <title>Omora Sidebar</title>
   <link rel="stylesheet" href="sidebar.css" />
 </head>
-<body class="light-theme">
+<body class="light-theme collapsed">
+  <button id="toggle-expand-btn" title="Expand">»</button>
   <button id="hide-sidebar-btn" title="Hide">×</button>
   <p>Omora Sidebar Ready</p>
 
-  <button id="settings-btn"><span aria-hidden="true">⚙️</span> Settings</button>
+  <button id="settings-btn">
+    <span class="icon" aria-hidden="true">⚙️</span>
+    <span class="label">Settings</span>
+  </button>
 
   <script src="sidebar.js"></script>
 </body>

--- a/sidebar.js
+++ b/sidebar.js
@@ -4,21 +4,54 @@ function applyTheme(theme) {
   body.classList.add(theme === 'dark' ? 'dark-theme' : 'light-theme');
 }
 
+function applyExpanded(expanded) {
+  const body = document.body;
+  body.classList.toggle('expanded', expanded);
+  body.classList.toggle('collapsed', !expanded);
+  const toggle = document.getElementById('toggle-expand-btn');
+  if (toggle) {
+    toggle.textContent = expanded ? '«' : '»';
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-  chrome.storage.local.get('sidebarTheme', ({ sidebarTheme }) => {
-    applyTheme(sidebarTheme || 'light');
-  });
+  chrome.storage.local.get(
+    ['sidebarTheme', 'sidebarExpanded'],
+    ({ sidebarTheme, sidebarExpanded }) => {
+      applyTheme(sidebarTheme || 'light');
+      applyExpanded(sidebarExpanded === true);
+    },
+  );
 
   chrome.storage.onChanged.addListener((changes, area) => {
-    if (area === 'local' && changes.sidebarTheme) {
-      applyTheme(changes.sidebarTheme.newValue || 'light');
+    if (area === 'local') {
+      if (changes.sidebarTheme) {
+        applyTheme(changes.sidebarTheme.newValue || 'light');
+      }
+      if (changes.sidebarExpanded) {
+        applyExpanded(changes.sidebarExpanded.newValue === true);
+      }
     }
   });
 
   const hideButton = document.getElementById('hide-sidebar-btn');
   if (hideButton) {
     hideButton.addEventListener('click', () => {
-      parent.postMessage({ type: 'hide-sidebar' }, '*');
+      chrome.storage.local.set({ sidebarVisible: false }, () => {
+        chrome.runtime.sendMessage({ type: 'hide-sidebar' });
+        parent.postMessage({ type: 'hide-sidebar' }, '*');
+      });
+    });
+  }
+
+  const toggleButton = document.getElementById('toggle-expand-btn');
+  if (toggleButton) {
+    toggleButton.addEventListener('click', () => {
+      chrome.storage.local.get('sidebarExpanded', ({ sidebarExpanded }) => {
+        const newValue = !(sidebarExpanded === true);
+        chrome.storage.local.set({ sidebarExpanded: newValue });
+        applyExpanded(newValue);
+      });
     });
   }
 
@@ -29,3 +62,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+


### PR DESCRIPTION
## Summary
- add expandable/collapsible sidebar UI with persistent state
- broadcast sidebar visibility and size changes across all tabs
- ensure new tab page always injects sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891fc3d2f5c83299afe51ababc7abc8