### PR TITLE
feat: inline sidebar settings view

### DIFF
--- a/sidebar.css
+++ b/sidebar.css
@@ -1,3 +1,8 @@
+html,
+body {
+  height: 100%;
+}
+
 body {
   font-family: Arial, sans-serif;
   margin: 0;
@@ -32,6 +37,16 @@ body {
   border: none;
   font-size: 16px;
   cursor: pointer;
+}
+
+#content-area {
+  height: 100%;
+}
+
+#content-area iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
 }
 
 #settings-btn {

--- a/sidebar.html
+++ b/sidebar.html
@@ -8,7 +8,10 @@
 <body class="light-theme collapsed">
   <button id="toggle-expand-btn" title="Expand">»</button>
   <button id="hide-sidebar-btn" title="Hide">×</button>
-  <p>Omora Sidebar Ready</p>
+
+  <div id="content-area">
+    <p>Omora Sidebar Ready</p>
+  </div>
 
   <button id="settings-btn">
     <span class="icon" aria-hidden="true">⚙️</span>

--- a/sidebar.js
+++ b/sidebar.js
@@ -14,12 +14,37 @@ function applyExpanded(expanded) {
   }
 }
 
+function showView(view) {
+  const contentArea = document.getElementById('content-area');
+  if (!contentArea) return;
+
+  currentView = view;
+  chrome.storage.local.set({ sidebarView: view });
+
+  contentArea.innerHTML = '';
+  if (view === 'settings') {
+    const iframe = document.createElement('iframe');
+    iframe.src = 'settings.html';
+    iframe.style.width = '100%';
+    iframe.style.height = '100%';
+    iframe.style.border = 'none';
+    contentArea.appendChild(iframe);
+  } else {
+    const homeDiv = document.createElement('div');
+    homeDiv.innerHTML = '<p>Omora Sidebar Ready</p>';
+    contentArea.appendChild(homeDiv);
+  }
+}
+
+let currentView = 'home';
+
 document.addEventListener('DOMContentLoaded', () => {
   chrome.storage.local.get(
-    ['sidebarTheme', 'sidebarExpanded'],
-    ({ sidebarTheme, sidebarExpanded }) => {
+    ['sidebarTheme', 'sidebarExpanded', 'sidebarView'],
+    ({ sidebarTheme, sidebarExpanded, sidebarView }) => {
       applyTheme(sidebarTheme || 'light');
       applyExpanded(sidebarExpanded === true);
+      showView(sidebarView === 'settings' ? 'settings' : 'home');
     },
   );
 
@@ -30,6 +55,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       if (changes.sidebarExpanded) {
         applyExpanded(changes.sidebarExpanded.newValue === true);
+      }
+      if (changes.sidebarView) {
+        showView(changes.sidebarView.newValue === 'settings' ? 'settings' : 'home');
       }
     }
   });
@@ -58,7 +86,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const settingsButton = document.getElementById('settings-btn');
   if (settingsButton) {
     settingsButton.addEventListener('click', () => {
-      chrome.tabs.create({ url: chrome.runtime.getURL('settings.html') });
+      showView(currentView === 'settings' ? 'home' : 'settings');
     });
   }
 });


### PR DESCRIPTION
## Summary
- Add content area to sidebar for inline view rendering
- Switch settings button to load settings iframe within sidebar
- Style content area to fill sidebar height and track last view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891ff2ae4808329b4aa2b137240f850