### PR TITLE
Load settings inline in sidebar

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', () => {
+function initSettings() {
   const toggle = document.getElementById('theme-toggle');
   if (!toggle) return;
 
@@ -10,5 +10,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const theme = toggle.checked ? 'dark' : 'light';
     chrome.storage.local.set({ sidebarTheme: theme });
   });
-});
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initSettings);
+} else {
+  initSettings();
+}
 

--- a/sidebar.html
+++ b/sidebar.html
@@ -9,9 +9,7 @@
   <button id="toggle-expand-btn" title="Expand">»</button>
   <button id="hide-sidebar-btn" title="Hide">×</button>
 
-  <div id="content-area">
-    <p>Omora Sidebar Ready</p>
-  </div>
+  <div id="content-area"></div>
 
   <button id="settings-btn">
     <span class="icon" aria-hidden="true">⚙️</span>

--- a/sidebar.js
+++ b/sidebar.js
@@ -23,12 +23,14 @@ function showView(view) {
 
   contentArea.innerHTML = '';
   if (view === 'settings') {
-    const iframe = document.createElement('iframe');
-    iframe.src = 'settings.html';
-    iframe.style.width = '100%';
-    iframe.style.height = '100%';
-    iframe.style.border = 'none';
-    contentArea.appendChild(iframe);
+    fetch(chrome.runtime.getURL('settings.html'))
+      .then((response) => response.text())
+      .then((html) => {
+        contentArea.innerHTML = html;
+        const script = document.createElement('script');
+        script.src = chrome.runtime.getURL('settings.js');
+        contentArea.appendChild(script);
+      });
   } else {
     const homeDiv = document.createElement('div');
     homeDiv.innerHTML = '<p>Omora Sidebar Ready</p>';


### PR DESCRIPTION
## Summary
- Render sidebar views in a dedicated `#content-area`
- Replace iframe-based settings view with inline fetch and script injection
- Ensure settings script initializes immediately for injected markup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920352a06c83298779f3c9a5858496