### PR TITLE
Toggle global sidebar via extension icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Minimal Chrome extension.
 
 ## Features
 
-- Adds a persistent, resizable sidebar on the right side of webpages.
-  The sidebar defaults to roughly 300px wide, shrinks page content to
+- Resizable sidebar on the right side of webpages.
+- Toggle the sidebar by clicking the Omora extension icon; visibility
+  is synchronized across all tabs and windows.
+- The sidebar defaults to roughly 300px wide, shrinks page content to
   accommodate its width, and stays hidden on restricted pages.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,11 @@
+chrome.action.onClicked.addListener(async () => {
+  const { sidebarVisible = false } = await chrome.storage.local.get('sidebarVisible');
+  const newState = !sidebarVisible;
+  await chrome.storage.local.set({ sidebarVisible: newState });
+  const tabs = await chrome.tabs.query({});
+  for (const tab of tabs) {
+    if (tab.id) {
+      chrome.tabs.sendMessage(tab.id, { sidebarVisible: newState });
+    }
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,10 @@
     "32": "public/icon32.png",
     "128": "public/icon128.png"
   },
+  "permissions": ["storage", "tabs"],
+  "background": {
+    "service_worker": "background.js"
+  },
   "content_scripts": [
     {
       "matches": ["<all_urls>"],

--- a/sidebar.js
+++ b/sidebar.js
@@ -5,32 +5,64 @@
       return;
     }
 
-    const sidebar = document.createElement('div');
-    sidebar.id = 'omora-sidebar';
-    Object.assign(sidebar.style, {
-      position: 'fixed',
-      top: '0',
-      right: '0',
-      width: '300px',
-      height: '100vh',
-      backgroundColor: '#fff',
-      borderLeft: '1px solid #ccc',
-      zIndex: '2147483647',
-      overflow: 'auto',
-      resize: 'horizontal',
-      minWidth: '150px',
-      maxWidth: '80vw'
-    });
-
-    body.appendChild(sidebar);
+    let sidebar;
+    let observer;
 
     const adjustBody = () => {
-      body.style.marginRight = `${sidebar.offsetWidth}px`;
+      if (sidebar) {
+        body.style.marginRight = `${sidebar.offsetWidth}px`;
+      } else {
+        body.style.marginRight = '';
+      }
     };
-    adjustBody();
 
-    const observer = new ResizeObserver(adjustBody);
-    observer.observe(sidebar);
+    const showSidebar = () => {
+      if (!sidebar) {
+        sidebar = document.createElement('div');
+        sidebar.id = 'omora-sidebar';
+        Object.assign(sidebar.style, {
+          position: 'fixed',
+          top: '0',
+          right: '0',
+          width: '300px',
+          height: '100vh',
+          backgroundColor: '#fff',
+          borderLeft: '1px solid #ccc',
+          zIndex: '2147483647',
+          overflow: 'auto',
+          resize: 'horizontal',
+          minWidth: '150px',
+          maxWidth: '80vw'
+        });
+        body.appendChild(sidebar);
+        observer = new ResizeObserver(adjustBody);
+        observer.observe(sidebar);
+      }
+      adjustBody();
+    };
+
+    const hideSidebar = () => {
+      if (sidebar) {
+        observer.disconnect();
+        sidebar.remove();
+        sidebar = undefined;
+      }
+      adjustBody();
+    };
+
+    chrome.storage.local.get('sidebarVisible', ({ sidebarVisible }) => {
+      if (sidebarVisible) {
+        showSidebar();
+      }
+    });
+
+    chrome.runtime.onMessage.addListener((message) => {
+      if (message.sidebarVisible === true) {
+        showSidebar();
+      } else if (message.sidebarVisible === false) {
+        hideSidebar();
+      }
+    });
   } catch (e) {
     /* Fail silently on restricted pages */
   }


### PR DESCRIPTION
## Summary
- allow clicking the Omora toolbar icon to show or hide a sidebar
- synchronize sidebar visibility across all tabs and windows
- document global sidebar toggle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894817d78588329bbab41dd93800848