### PR TITLE
feat: add left-edge resize handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Minimal Chrome extension.
 
 ## Features
 
-- Resizable sidebar on the right side of webpages.
+- Sidebar on the right side of webpages resizable by dragging its left edge (minimum width 50px).
 - Toggle the sidebar by clicking the Omora extension icon; visibility
   is synchronized across all tabs and windows.
 - The sidebar defaults to roughly 300px wide, shrinks page content to


### PR DESCRIPTION
## Summary
- Allow the sidebar to be resized by dragging its left edge with a 50px minimum width
- Document sidebar resizing behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894834bf5d88329a2f69a51742fc87e