### PR TITLE
Add responsive sidebar button scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Minimal Chrome extension.
   is synchronized across all tabs and windows.
 - The sidebar defaults to roughly 300px wide, shrinks page content to
   accommodate its width, and stays hidden on restricted pages.
+- Scaffold for sidebar buttons. Buttons show their icon and label when
+  the sidebar exceeds 100px and collapse to icons only when narrower.
+  New buttons can be added at runtime via `window.omoraAddButton`.

--- a/sidebar.js
+++ b/sidebar.js
@@ -8,14 +8,86 @@
     let sidebar;
     let observer;
     let handle;
+    let buttonsContainer;
     let isResizing = false;
     let startResize;
     let onMouseMove;
     let stopResize;
 
+    const existingStyle = document.getElementById('omora-sidebar-style');
+    if (!existingStyle) {
+      const style = document.createElement('style');
+      style.id = 'omora-sidebar-style';
+      style.textContent = `
+        #omora-sidebar {
+          display: flex;
+          flex-direction: column;
+          font-family: sans-serif;
+        }
+        #omora-sidebar .omora-button {
+          display: flex;
+          align-items: center;
+          gap: 8px;
+          padding: 8px;
+          border: none;
+          background: none;
+          width: 100%;
+          text-align: left;
+          cursor: pointer;
+        }
+        #omora-sidebar.collapsed .omora-button .label {
+          display: none;
+        }
+      `;
+      document.head.appendChild(style);
+    }
+
+    const updateSidebarState = () => {
+      if (!sidebar) {
+        return;
+      }
+      if (sidebar.offsetWidth <= 100) {
+        sidebar.classList.add('collapsed');
+      } else {
+        sidebar.classList.remove('collapsed');
+      }
+    };
+
+    const buttonConfigs = [];
+
+    const createButton = ({ icon, label, onClick }) => {
+      const btn = document.createElement('button');
+      btn.className = 'omora-button';
+      const iconSpan = document.createElement('span');
+      iconSpan.className = 'icon';
+      iconSpan.textContent = icon;
+      const labelSpan = document.createElement('span');
+      labelSpan.className = 'label';
+      labelSpan.textContent = label;
+      btn.append(iconSpan, labelSpan);
+      if (onClick) {
+        btn.addEventListener('click', onClick);
+      }
+      return btn;
+    };
+
+    const addButton = (config) => {
+      buttonConfigs.push(config);
+      if (buttonsContainer) {
+        buttonsContainer.appendChild(createButton(config));
+        updateSidebarState();
+      }
+    };
+
+    window.omoraAddButton = addButton;
+
+    addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
+    addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked') });
+
     const adjustBody = () => {
       if (sidebar) {
         body.style.marginRight = `${sidebar.offsetWidth}px`;
+        updateSidebarState();
       } else {
         body.style.marginRight = '';
       }
@@ -49,6 +121,14 @@
         });
         sidebar.appendChild(handle);
 
+        buttonsContainer = document.createElement('div');
+        buttonsContainer.style.marginLeft = '5px';
+        sidebar.appendChild(buttonsContainer);
+
+        buttonConfigs.forEach((cfg) => {
+          buttonsContainer.appendChild(createButton(cfg));
+        });
+
         onMouseMove = (e) => {
           if (!isResizing) {
             return;
@@ -76,7 +156,7 @@
         };
 
         handle.addEventListener('mousedown', startResize);
-
+        
         body.appendChild(sidebar);
         observer = new ResizeObserver(adjustBody);
         observer.observe(sidebar);
@@ -93,6 +173,7 @@
         handle.removeEventListener('mousedown', startResize);
         sidebar.remove();
         sidebar = undefined;
+        buttonsContainer = undefined;
       }
       adjustBody();
     };


### PR DESCRIPTION
## Summary
- make sidebar buttons responsive: show icon + label when width > 100, icons only when ≤ 100
- expose `window.omoraAddButton` to add buttons easily
- document button scaffold behavior in README

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68948573d10083299b00a4acce7c51a0