### PR TITLE
Add sidebar expand/collapse toggle button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,6 @@ Minimal Chrome extension.
 - Scaffold for sidebar buttons. Buttons show their icon and label when
   the sidebar exceeds 100px and collapse to icons only when narrower.
   New buttons can be added at runtime via `window.omoraAddButton`.
+- Expand/Collapse toggle button at the top. It animates the sidebar
+  width between 50px and 200px over 0.5s and rotates its chevron icon
+  180° to indicate the state.

--- a/sidebar.js
+++ b/sidebar.js
@@ -23,6 +23,7 @@
           display: flex;
           flex-direction: column;
           font-family: sans-serif;
+          transition: width 0.5s;
         }
         #omora-sidebar .omora-button {
           display: flex;
@@ -37,6 +38,24 @@
         }
         #omora-sidebar.collapsed .omora-button .label {
           display: none;
+        }
+        #omora-sidebar .expand-toggle {
+          display: flex;
+          justify-content: center;
+          align-items: center;
+          padding: 8px;
+          border: none;
+          background: none;
+          width: 100%;
+          cursor: pointer;
+        }
+        #omora-sidebar .expand-toggle .icon {
+          display: inline-block;
+          transition: transform 0.5s;
+          transform: rotate(180deg);
+        }
+        #omora-sidebar.collapsed .expand-toggle .icon {
+          transform: rotate(0deg);
         }
       `;
       document.head.appendChild(style);
@@ -121,6 +140,24 @@
         });
         sidebar.appendChild(handle);
 
+        const toggleButton = document.createElement('button');
+        toggleButton.className = 'expand-toggle';
+        toggleButton.style.marginLeft = '5px';
+        const chevron = document.createElement('span');
+        chevron.className = 'icon';
+        chevron.textContent = '\u276F';
+        toggleButton.appendChild(chevron);
+        toggleButton.addEventListener('click', () => {
+          const targetWidth = sidebar.offsetWidth > 100 ? 50 : 200;
+          sidebar.style.width = `${targetWidth}px`;
+          if (targetWidth <= 100) {
+            sidebar.classList.add('collapsed');
+          } else {
+            sidebar.classList.remove('collapsed');
+          }
+        });
+        sidebar.appendChild(toggleButton);
+
         buttonsContainer = document.createElement('div');
         buttonsContainer.style.marginLeft = '5px';
         sidebar.appendChild(buttonsContainer);
@@ -145,10 +182,12 @@
           document.removeEventListener('mousemove', onMouseMove);
           document.removeEventListener('mouseup', stopResize);
           body.style.userSelect = '';
+          sidebar.style.transition = '';
         };
 
         startResize = (e) => {
           isResizing = true;
+          sidebar.style.transition = 'none';
           document.addEventListener('mousemove', onMouseMove);
           document.addEventListener('mouseup', stopResize);
           body.style.userSelect = 'none';
@@ -156,7 +195,7 @@
         };
 
         handle.addEventListener('mousedown', startResize);
-        
+
         body.appendChild(sidebar);
         observer = new ResizeObserver(adjustBody);
         observer.observe(sidebar);


### PR DESCRIPTION
## Summary
- add a dedicated toggle button at the top of the sidebar
- animate sidebar width between collapsed and expanded states with chevron rotation
- document new expand/collapse feature

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689488696c3483298626418f5804df3f