### PR TITLE
Extract sidebar styles into standalone CSS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ Minimal Chrome extension.
 - Expand/Collapse toggle button at the top. It animates the sidebar
   width between 50px and 200px over 0.5s and rotates its chevron icon
   180° to indicate the state.
+- Styling for the sidebar lives in a dedicated `sidebar.css` file for
+  easier customization.

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "css": ["sidebar.css"],
       "js": ["sidebar.js"],
       "run_at": "document_end"
     }

--- a/sidebar.css
+++ b/sidebar.css
@@ -1,0 +1,71 @@
+/* Sidebar styles for the Omora extension */
+
+#omora-sidebar {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 300px;
+  height: 100vh;
+  background-color: #fff;
+  border-left: 1px solid #ccc;
+  z-index: 2147483647;
+  overflow: auto;
+  min-width: 50px;
+  max-width: 80vw;
+  display: flex;
+  flex-direction: column;
+  font-family: sans-serif;
+  transition: width 0.5s;
+}
+
+#omora-sidebar .resize-handle {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 5px;
+  height: 100%;
+  cursor: ew-resize;
+}
+
+#omora-sidebar .expand-toggle {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px;
+  border: none;
+  background: none;
+  width: 100%;
+  cursor: pointer;
+  margin-left: 5px;
+}
+
+#omora-sidebar .expand-toggle .icon {
+  display: inline-block;
+  transition: transform 0.5s;
+  transform: rotate(180deg);
+}
+
+#omora-sidebar.collapsed .expand-toggle .icon {
+  transform: rotate(0deg);
+}
+
+#omora-sidebar .buttons-container {
+  margin-left: 5px;
+}
+
+#omora-sidebar .omora-button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+}
+
+#omora-sidebar.collapsed .omora-button .label {
+  display: none;
+}
+

--- a/sidebar.js
+++ b/sidebar.js
@@ -14,53 +14,6 @@
     let onMouseMove;
     let stopResize;
 
-    const existingStyle = document.getElementById('omora-sidebar-style');
-    if (!existingStyle) {
-      const style = document.createElement('style');
-      style.id = 'omora-sidebar-style';
-      style.textContent = `
-        #omora-sidebar {
-          display: flex;
-          flex-direction: column;
-          font-family: sans-serif;
-          transition: width 0.5s;
-        }
-        #omora-sidebar .omora-button {
-          display: flex;
-          align-items: center;
-          gap: 8px;
-          padding: 8px;
-          border: none;
-          background: none;
-          width: 100%;
-          text-align: left;
-          cursor: pointer;
-        }
-        #omora-sidebar.collapsed .omora-button .label {
-          display: none;
-        }
-        #omora-sidebar .expand-toggle {
-          display: flex;
-          justify-content: center;
-          align-items: center;
-          padding: 8px;
-          border: none;
-          background: none;
-          width: 100%;
-          cursor: pointer;
-        }
-        #omora-sidebar .expand-toggle .icon {
-          display: inline-block;
-          transition: transform 0.5s;
-          transform: rotate(180deg);
-        }
-        #omora-sidebar.collapsed .expand-toggle .icon {
-          transform: rotate(0deg);
-        }
-      `;
-      document.head.appendChild(style);
-    }
-
     const updateSidebarState = () => {
       if (!sidebar) {
         return;
@@ -116,33 +69,13 @@
       if (!sidebar) {
         sidebar = document.createElement('div');
         sidebar.id = 'omora-sidebar';
-        Object.assign(sidebar.style, {
-          position: 'fixed',
-          top: '0',
-          right: '0',
-          width: '300px',
-          height: '100vh',
-          backgroundColor: '#fff',
-          borderLeft: '1px solid #ccc',
-          zIndex: '2147483647',
-          overflow: 'auto',
-          minWidth: '50px',
-          maxWidth: '80vw'
-        });
+
         handle = document.createElement('div');
-        Object.assign(handle.style, {
-          position: 'absolute',
-          top: '0',
-          left: '0',
-          width: '5px',
-          height: '100%',
-          cursor: 'ew-resize'
-        });
+        handle.className = 'resize-handle';
         sidebar.appendChild(handle);
 
         const toggleButton = document.createElement('button');
         toggleButton.className = 'expand-toggle';
-        toggleButton.style.marginLeft = '5px';
         const chevron = document.createElement('span');
         chevron.className = 'icon';
         chevron.textContent = '\u276F';
@@ -159,7 +92,7 @@
         sidebar.appendChild(toggleButton);
 
         buttonsContainer = document.createElement('div');
-        buttonsContainer.style.marginLeft = '5px';
+        buttonsContainer.className = 'buttons-container';
         sidebar.appendChild(buttonsContainer);
 
         buttonConfigs.forEach((cfg) => {


### PR DESCRIPTION
## Summary
- move styling rules out of `sidebar.js` into new `sidebar.css`
- load the stylesheet via the manifest and rely on CSS classes instead of inline styles
- document the separate stylesheet in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948e400af083299ab9d973cd40ac39