### PR TITLE
Align sidebar controls and pin settings button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Minimal Chrome extension.
   the sidebar exceeds 100px and collapse to icons only when narrower.
   New buttons can be added at runtime via `window.omoraAddButton`.
 - Expand/Collapse toggle button at the top. It animates the sidebar
-  width between 50px and 200px over 0.5s and rotates its chevron icon
-  180° to indicate the state.
+  width between 50px and 200px over 0.5s, shows a "Collaps" label when
+  expanded, and rotates its chevron icon 180° to indicate the state.
+- Icons (including the chevron) center themselves when the sidebar is
+  collapsed so the toggle aligns with other buttons.
+- A persistent Settings button is anchored to the bottom of the sidebar.
 - Styling for the sidebar lives in a dedicated `sidebar.css` file for
   easier customization.

--- a/sidebar.css
+++ b/sidebar.css
@@ -28,15 +28,8 @@
 }
 
 #omora-sidebar .expand-toggle {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 8px;
-  border: none;
-  background: none;
-  width: 100%;
-  cursor: pointer;
   margin-left: 5px;
+  justify-content: flex-start;
 }
 
 #omora-sidebar .expand-toggle .icon {
@@ -45,12 +38,36 @@
   transform: rotate(180deg);
 }
 
+#omora-sidebar.collapsed .expand-toggle {
+  margin-left: 0;
+}
+
 #omora-sidebar.collapsed .expand-toggle .icon {
   transform: rotate(0deg);
 }
 
+#omora-sidebar .expand-toggle .label {
+}
+
+#omora-sidebar.collapsed .expand-toggle .label {
+  display: none;
+}
+
 #omora-sidebar .buttons-container {
   margin-left: 5px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
+#omora-sidebar .bottom-buttons {
+  margin-left: 5px;
+  margin-top: auto;
+}
+
+#omora-sidebar.collapsed .buttons-container,
+#omora-sidebar.collapsed .bottom-buttons {
+  margin-left: 0;
 }
 
 #omora-sidebar .omora-button {
@@ -63,6 +80,11 @@
   width: 100%;
   text-align: left;
   cursor: pointer;
+}
+
+#omora-sidebar.collapsed .omora-button,
+#omora-sidebar.collapsed .expand-toggle {
+  justify-content: center;
 }
 
 #omora-sidebar.collapsed .omora-button .label {

--- a/sidebar.js
+++ b/sidebar.js
@@ -9,6 +9,7 @@
     let observer;
     let handle;
     let buttonsContainer;
+    let bottomButtonsContainer;
     let isResizing = false;
     let startResize;
     let onMouseMove;
@@ -26,6 +27,7 @@
     };
 
     const buttonConfigs = [];
+    const bottomButtonConfigs = [];
 
     const createButton = ({ icon, label, onClick }) => {
       const btn = document.createElement('button');
@@ -44,9 +46,11 @@
     };
 
     const addButton = (config) => {
-      buttonConfigs.push(config);
-      if (buttonsContainer) {
-        buttonsContainer.appendChild(createButton(config));
+      const list = config.position === 'bottom' ? bottomButtonConfigs : buttonConfigs;
+      list.push(config);
+      const container = config.position === 'bottom' ? bottomButtonsContainer : buttonsContainer;
+      if (container) {
+        container.appendChild(createButton(config));
         updateSidebarState();
       }
     };
@@ -54,7 +58,7 @@
     window.omoraAddButton = addButton;
 
     addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
-    addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked') });
+    addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });
 
     const adjustBody = () => {
       if (sidebar) {
@@ -74,12 +78,8 @@
         handle.className = 'resize-handle';
         sidebar.appendChild(handle);
 
-        const toggleButton = document.createElement('button');
-        toggleButton.className = 'expand-toggle';
-        const chevron = document.createElement('span');
-        chevron.className = 'icon';
-        chevron.textContent = '\u276F';
-        toggleButton.appendChild(chevron);
+        const toggleButton = createButton({ icon: '\u276F', label: 'Collaps' });
+        toggleButton.classList.add('expand-toggle');
         toggleButton.addEventListener('click', () => {
           const targetWidth = sidebar.offsetWidth > 100 ? 50 : 200;
           sidebar.style.width = `${targetWidth}px`;
@@ -95,8 +95,16 @@
         buttonsContainer.className = 'buttons-container';
         sidebar.appendChild(buttonsContainer);
 
+        bottomButtonsContainer = document.createElement('div');
+        bottomButtonsContainer.className = 'bottom-buttons';
+        sidebar.appendChild(bottomButtonsContainer);
+
         buttonConfigs.forEach((cfg) => {
           buttonsContainer.appendChild(createButton(cfg));
+        });
+
+        bottomButtonConfigs.forEach((cfg) => {
+          bottomButtonsContainer.appendChild(createButton(cfg));
         });
 
         onMouseMove = (e) => {
@@ -146,6 +154,7 @@
         sidebar.remove();
         sidebar = undefined;
         buttonsContainer = undefined;
+        bottomButtonsContainer = undefined;
       }
       adjustBody();
     };


### PR DESCRIPTION
## Summary
- add support for bottom-positioned buttons and pin Settings at the sidebar's base
- show a "Collaps" label on the expand toggle and center icons when the sidebar is collapsed
- document updated sidebar behavior in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689490f079d883299a948fe44f20587b