### PR TITLE
feat: auto theme based on page background

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ Minimal Chrome extension.
 - A persistent Settings button is anchored to the bottom of the sidebar.
 - Styling for the sidebar lives in a dedicated `sidebar.css` file for
   easier customization.
+- Automatically matches the page's background color and switches between
+  light and dark sidebar themes. The theme can be overridden before
+  initialization via `window.omoraForceTheme`.

--- a/sidebar.css
+++ b/sidebar.css
@@ -18,6 +18,14 @@
   transition: width 0.5s;
 }
 
+#omora-sidebar.omora-theme-dark {
+  color: #fff;
+}
+
+#omora-sidebar.omora-theme-light {
+  color: #000;
+}
+
 #omora-sidebar .resize-handle {
   position: absolute;
   top: 0;

--- a/sidebar.js
+++ b/sidebar.js
@@ -14,6 +14,9 @@
     let startResize;
     let onMouseMove;
     let stopResize;
+    let detectedBg;
+    let themeClass;
+    let themeComputed = false;
 
     const updateSidebarState = () => {
       if (!sidebar) {
@@ -60,6 +63,31 @@
     addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });
 
+    const detectTheme = () => {
+      if (themeComputed) {
+        return;
+      }
+      themeComputed = true;
+      let bg = getComputedStyle(body).backgroundColor;
+      if (!bg || bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)') {
+        bg = getComputedStyle(document.documentElement).backgroundColor;
+      }
+      detectedBg = bg;
+      const force = window.omoraForceTheme;
+      if (force === 'light' || force === 'dark') {
+        themeClass = force === 'light' ? 'omora-theme-light' : 'omora-theme-dark';
+        return;
+      }
+      const match = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+      if (match) {
+        const r = parseInt(match[1], 10);
+        const g = parseInt(match[2], 10);
+        const b = parseInt(match[3], 10);
+        const brightness = (r * 299 + g * 587 + b * 114) / 1000;
+        themeClass = brightness < 128 ? 'omora-theme-light' : 'omora-theme-dark';
+      }
+    };
+
     const adjustBody = () => {
       if (sidebar) {
         body.style.marginRight = `${sidebar.offsetWidth}px`;
@@ -71,8 +99,15 @@
 
     const showSidebar = () => {
       if (!sidebar) {
+        detectTheme();
         sidebar = document.createElement('div');
         sidebar.id = 'omora-sidebar';
+        if (detectedBg) {
+          sidebar.style.backgroundColor = detectedBg;
+        }
+        if (themeClass) {
+          sidebar.classList.add(themeClass);
+        }
 
         handle = document.createElement('div');
         handle.className = 'resize-handle';


### PR DESCRIPTION
## Summary
- detect host page background color once and infer theme
- apply detected color to sidebar and switch light/dark class
- document new theme behavior and override option

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689494a65b188329a8427c96b74b5524