### PR TITLE
feat: respect system dark mode for sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Minimal Chrome extension.
 - A persistent Settings button is anchored to the bottom of the sidebar.
 - Styling for the sidebar lives in a dedicated `sidebar.css` file for
   easier customization.
-- Automatically matches the page's background color and switches between
-  light and dark sidebar themes. The theme can be overridden before
-  initialization via `window.omoraForceTheme`.
+- Automatically selects a light or dark sidebar theme with the following
+  priority: a global `window.omoraForceTheme` override, the user's
+  operating system dark mode preference, and finally the page's
+  background brightness. A default dark background is used when dark
+  mode is active.

--- a/sidebar.js
+++ b/sidebar.js
@@ -68,23 +68,35 @@
         return;
       }
       themeComputed = true;
+      const force = window.omoraForceTheme;
+      if (force === 'light' || force === 'dark') {
+        themeClass = force === 'light' ? 'omora-theme-light' : 'omora-theme-dark';
+        if (themeClass === 'omora-theme-dark') {
+          detectedBg = '#1e1e1e';
+        }
+        return;
+      }
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (prefersDark) {
+        themeClass = 'omora-theme-dark';
+        detectedBg = '#1e1e1e';
+        return;
+      }
       let bg = getComputedStyle(body).backgroundColor;
       if (!bg || bg === 'transparent' || bg === 'rgba(0, 0, 0, 0)') {
         bg = getComputedStyle(document.documentElement).backgroundColor;
       }
       detectedBg = bg;
-      const force = window.omoraForceTheme;
-      if (force === 'light' || force === 'dark') {
-        themeClass = force === 'light' ? 'omora-theme-light' : 'omora-theme-dark';
-        return;
-      }
-      const match = bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
+      const match = bg && bg.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
       if (match) {
         const r = parseInt(match[1], 10);
         const g = parseInt(match[2], 10);
         const b = parseInt(match[3], 10);
         const brightness = (r * 299 + g * 587 + b * 114) / 1000;
         themeClass = brightness < 128 ? 'omora-theme-light' : 'omora-theme-dark';
+      }
+      if (themeClass === 'omora-theme-dark' && (!detectedBg || detectedBg === 'transparent' || detectedBg === 'rgba(0, 0, 0, 0)')) {
+        detectedBg = '#1e1e1e';
       }
     };
 


### PR DESCRIPTION
## Summary
- honor `window.omoraForceTheme` and OS dark-mode preference before falling back to page background brightness
- apply a default dark background when dark mode is chosen
- document theme selection priority in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949686bc108329889e2f841ce8a494