### PR TITLE
Hide sidebar scrollbars and adapt text color to theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Minimal Chrome extension.
   operating system dark mode preference, and finally the page's
   background brightness. A default dark background is used when dark
   mode is active.
+- Sidebar text automatically switches to white in dark mode and black in light mode.
+- Scrollbars inside the sidebar are hidden for a cleaner appearance.

--- a/sidebar.css
+++ b/sidebar.css
@@ -10,12 +10,18 @@
   border-left: 1px solid #ccc;
   z-index: 2147483647;
   overflow: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
   min-width: 50px;
   max-width: 80vw;
   display: flex;
   flex-direction: column;
   font-family: sans-serif;
   transition: width 0.5s;
+}
+
+#omora-sidebar::-webkit-scrollbar {
+  display: none;
 }
 
 #omora-sidebar.omora-theme-dark {
@@ -76,6 +82,10 @@
 #omora-sidebar.collapsed .buttons-container,
 #omora-sidebar.collapsed .bottom-buttons {
   margin-left: 0;
+}
+
+#omora-sidebar button {
+  color: inherit;
 }
 
 #omora-sidebar .omora-button {


### PR DESCRIPTION
## Summary
- Ensure sidebar text uses theme colors by inheriting white in dark mode and black in light mode
- Remove visible scrollbars from the sidebar for a cleaner UI
- Document the new text-color behavior and scrollbar removal in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894981c54cc832999f781f24d04d590