### PR TITLE
Ensure white text and chevron in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ Minimal Chrome extension.
   operating system dark mode preference, and finally the page's
   background brightness. A default dark background is used when dark
   mode is active.
-- Sidebar text automatically switches to white in dark mode and black in light mode.
+- All sidebar text and the chevron icon switch to white in dark mode and to black in light mode.
 - Scrollbars inside the sidebar are hidden for a cleaner appearance.

--- a/sidebar.css
+++ b/sidebar.css
@@ -24,8 +24,10 @@
   display: none;
 }
 
-#omora-sidebar.omora-theme-dark {
-  color: #fff;
+#omora-sidebar.omora-theme-dark,
+#omora-sidebar.omora-theme-dark * {
+  color: #fff !important;
+  fill: #fff !important;
 }
 
 #omora-sidebar.omora-theme-light {


### PR DESCRIPTION
## Summary
- force white text and chevron in dark mode via stronger CSS rules
- document dark-mode text behavior in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68949ad389b083299db128249db86019