### PR TITLE
Add appearance settings tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,5 @@ Minimal Chrome extension.
 - All sidebar text and the chevron icon switch between white and black
   according to the selected theme.
 - Scrollbars inside the sidebar are hidden for a cleaner appearance.
+- "Appearance" settings tab lets you set a custom background image or chat
+  bubble color with live preview and localStorage persistence.

--- a/settingsAppearance.css
+++ b/settingsAppearance.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: sans-serif;
+  display: flex;
+  min-height: 100vh;
+}
+
+.settings-nav {
+  width: 150px;
+  border-right: 1px solid #ddd;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-nav .tab {
+  background: none;
+  border: none;
+  padding: 10px;
+  text-align: left;
+  cursor: pointer;
+  font-size: 14px;
+}
+
+.settings-nav .tab.active {
+  font-weight: bold;
+}
+
+main {
+  flex: 1;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.section h2 {
+  margin-top: 0;
+}
+
+.radio-group {
+  display: flex;
+  gap: 15px;
+}
+
+#custom-bg {
+  margin-top: 10px;
+}
+
+.preview {
+  margin-top: 10px;
+  width: 100%;
+  max-width: 300px;
+  height: 150px;
+  border: 1px solid #ccc;
+  background-size: cover;
+  background-position: center;
+}
+
+.color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 40px);
+  gap: 10px;
+}
+
+.color-option {
+  width: 40px;
+  height: 40px;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+
+.color-option:hover {
+  transform: scale(1.1);
+}
+
+.color-option.selected {
+  outline: 2px solid #000;
+}
+
+.hidden {
+  display: none;
+}

--- a/settingsAppearance.html
+++ b/settingsAppearance.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Omora Settings - Appearance</title>
+  <link rel="stylesheet" href="settingsAppearance.css" />
+</head>
+<body>
+  <nav class="settings-nav">
+    <button class="tab active">Appearance</button>
+  </nav>
+  <main>
+    <section class="section">
+      <h2>Background</h2>
+      <div class="radio-group">
+        <label><input type="radio" name="background" value="none" /> None</label>
+        <label><input type="radio" name="background" value="default" /> Default</label>
+        <label><input type="radio" name="background" value="custom" /> Custom</label>
+      </div>
+      <div id="custom-bg" class="hidden">
+        <input type="file" id="bg-file" accept="image/*" />
+      </div>
+      <div id="background-preview" class="preview"></div>
+    </section>
+
+    <section class="section">
+      <h2>Chatbubble Color</h2>
+      <div class="color-grid">
+        <button class="color-option" data-color="#4CAF50" style="background-color:#4CAF50;"></button>
+        <button class="color-option" data-color="#2196F3" style="background-color:#2196F3;"></button>
+        <button class="color-option" data-color="#FFC107" style="background-color:#FFC107;"></button>
+        <button class="color-option" data-color="#E91E63" style="background-color:#E91E63;"></button>
+        <button class="color-option" data-color="#9C27B0" style="background-color:#9C27B0;"></button>
+        <button class="color-option" data-color="#FF5722" style="background-color:#FF5722;"></button>
+        <button class="color-option" data-color="#795548" style="background-color:#795548;"></button>
+        <button class="color-option" data-color="#607D8B" style="background-color:#607D8B;"></button>
+      </div>
+    </section>
+  </main>
+  <script src="settingsAppearance.js"></script>
+</body>
+</html>

--- a/settingsAppearance.js
+++ b/settingsAppearance.js
@@ -1,0 +1,78 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const bgRadios = document.querySelectorAll('input[name="background"]');
+  const customBgSection = document.getElementById('custom-bg');
+  const fileInput = document.getElementById('bg-file');
+  const preview = document.getElementById('background-preview');
+  const colorButtons = document.querySelectorAll('.color-option');
+
+  const applyBackground = (type, image) => {
+    if (type === 'custom' && image) {
+      preview.style.backgroundImage = `url(${image})`;
+      preview.style.backgroundColor = '';
+    } else if (type === 'none') {
+      preview.style.backgroundImage = '';
+      preview.style.backgroundColor = 'transparent';
+    } else {
+      preview.style.backgroundImage = '';
+      preview.style.backgroundColor = '';
+    }
+  };
+
+  const setBg = (type) => {
+    localStorage.setItem('omoraBgType', type);
+    if (type !== 'custom') {
+      localStorage.removeItem('omoraBgImage');
+    }
+    applyBackground(type, localStorage.getItem('omoraBgImage'));
+    customBgSection.classList.toggle('hidden', type !== 'custom');
+  };
+
+  bgRadios.forEach((radio) => {
+    radio.addEventListener('change', () => {
+      setBg(radio.value);
+    });
+  });
+
+  fileInput.addEventListener('change', () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const dataUrl = e.target.result;
+      localStorage.setItem('omoraBgImage', dataUrl);
+      localStorage.setItem('omoraBgType', 'custom');
+      document.querySelector('input[value="custom"]').checked = true;
+      applyBackground('custom', dataUrl);
+    };
+    reader.readAsDataURL(file);
+  });
+
+  const setColor = (color) => {
+    localStorage.setItem('omoraBubbleColor', color);
+    document.documentElement.style.setProperty('--chatbubble-color', color);
+    colorButtons.forEach((btn) => {
+      btn.classList.toggle('selected', btn.dataset.color === color);
+    });
+  };
+
+  colorButtons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      setColor(btn.dataset.color);
+    });
+  });
+
+  const savedBgType = localStorage.getItem('omoraBgType') || 'default';
+  const savedBgImage = localStorage.getItem('omoraBgImage');
+  const savedColor = localStorage.getItem('omoraBubbleColor');
+
+  const initialRadio = document.querySelector(`input[name="background"][value="${savedBgType}"]`);
+  if (initialRadio) {
+    initialRadio.checked = true;
+  }
+  customBgSection.classList.toggle('hidden', savedBgType !== 'custom');
+  applyBackground(savedBgType, savedBgImage);
+
+  if (savedColor) {
+    setColor(savedColor);
+  }
+});


### PR DESCRIPTION
## Summary
- add Appearance settings tab for custom backgrounds and chat bubble colors
- persist user selections in localStorage and load on page start
- document new Appearance tab in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c349eb888329afb4fa03dfbf5038