### PR TITLE
feat: inject ChatGPT appearance settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ Minimal Chrome extension.
 - Scrollbars inside the sidebar are hidden for a cleaner appearance.
 - "Appearance" settings tab lets you set a custom background image or chat
   bubble color with live preview and localStorage persistence.
+- Saved appearance settings are automatically injected into ChatGPT pages
+  (https://chat.openai.com/*), applying background and user chat bubble colors
+  in real time.

--- a/appearanceInjector.js
+++ b/appearanceInjector.js
@@ -1,0 +1,85 @@
+// Content script to inject appearance settings on ChatGPT pages
+(function() {
+  'use strict';
+
+  const CHAT_CONTAINER_SELECTOR = 'main';
+  const USER_BUBBLE_SELECTOR = '[data-message-author-role="user"], .user, [class*="user"]';
+
+  function getChatContainer() {
+    return document.querySelector(CHAT_CONTAINER_SELECTOR);
+  }
+
+  function applyBackground() {
+    const container = getChatContainer();
+    if (!container) return;
+
+    const type = localStorage.getItem('omoraBgType');
+    if (type === 'none') {
+      container.style.backgroundImage = 'none';
+      container.style.backgroundColor = '#ffffff';
+    } else if (type === 'custom') {
+      const img = localStorage.getItem('omoraBgImage');
+      if (img) {
+        container.style.backgroundImage = `url(${img})`;
+        container.style.backgroundSize = 'cover';
+        container.style.backgroundPosition = 'center';
+        container.style.backgroundRepeat = 'no-repeat';
+        container.style.backgroundColor = '';
+      }
+    } else {
+      container.style.backgroundImage = '';
+      container.style.backgroundColor = '';
+    }
+  }
+
+  function applyChatBubbleColor() {
+    const color = localStorage.getItem('omoraBubbleColor');
+    if (!color) return;
+
+    const bubbles = document.querySelectorAll(USER_BUBBLE_SELECTOR);
+    bubbles.forEach(b => {
+      b.style.backgroundColor = color;
+    });
+  }
+
+  function observeMessages() {
+    const container = getChatContainer();
+    if (!container) return;
+
+    const observer = new MutationObserver(mutations => {
+      mutations.forEach(mutation => {
+        mutation.addedNodes.forEach(node => {
+          if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+          if (node.matches && node.matches(USER_BUBBLE_SELECTOR)) {
+            node.style.backgroundColor = localStorage.getItem('omoraBubbleColor') || '';
+          }
+
+          if (node.querySelectorAll) {
+            const bubbles = node.querySelectorAll(USER_BUBBLE_SELECTOR);
+            bubbles.forEach(b => {
+              b.style.backgroundColor = localStorage.getItem('omoraBubbleColor') || '';
+            });
+          }
+        });
+      });
+    });
+
+    observer.observe(container, { childList: true, subtree: true });
+  }
+
+  function initAppearance() {
+    applyBackground();
+    applyChatBubbleColor();
+    observeMessages();
+
+    window.addEventListener('storage', e => {
+      if (['omoraBgType', 'omoraBgImage', 'omoraBubbleColor'].includes(e.key)) {
+        applyBackground();
+        applyChatBubbleColor();
+      }
+    });
+  }
+
+  initAppearance();
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -18,6 +18,11 @@
       "css": ["sidebar.css"],
       "js": ["sidebar.js"],
       "run_at": "document_end"
+    },
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["appearanceInjector.js"],
+      "run_at": "document_end"
     }
   ],
   "action": {


### PR DESCRIPTION
## Summary
- add appearanceInjector content script that reads Appearance settings from localStorage and applies them to ChatGPT pages
- include script in manifest to run on chat.openai.com
- document automatic ChatGPT appearance injection in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c5639d2083298be5ed04d4e5caba