### PR TITLE
Add dynamic per-site settings scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,5 @@ Minimal Chrome extension.
 - Saved appearance settings are automatically injected into ChatGPT pages
   (https://chat.openai.com/*), applying background and user chat bubble colors
   in real time.
+- When browsing supported sites, a domain-specific button (e.g., "ChatGPT Features")
+  appears in the sidebar and opens a settings panel for that site's custom options.

--- a/features/chatgpt.js
+++ b/features/chatgpt.js
@@ -1,0 +1,134 @@
+export default function init(container, domain) {
+  const prefix = `omora_${domain}_`;
+
+  // Background section
+  const bgSection = document.createElement('div');
+  bgSection.className = 'section';
+  const bgTitle = document.createElement('h3');
+  bgTitle.textContent = 'Background';
+  bgSection.appendChild(bgTitle);
+
+  const radioGroup = document.createElement('div');
+  radioGroup.className = 'radio-group';
+
+  const bgOptions = [
+    { value: 'none', label: 'None' },
+    { value: 'default', label: 'Default' },
+    { value: 'custom', label: 'Custom' }
+  ];
+
+  bgOptions.forEach(({ value, label }) => {
+    const lbl = document.createElement('label');
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = `${domain}-bg`;
+    input.value = value;
+    lbl.appendChild(input);
+    lbl.appendChild(document.createTextNode(label));
+    radioGroup.appendChild(lbl);
+  });
+
+  bgSection.appendChild(radioGroup);
+
+  const customBg = document.createElement('div');
+  customBg.id = 'custom-bg';
+  const fileInput = document.createElement('input');
+  fileInput.type = 'file';
+  customBg.appendChild(fileInput);
+  bgSection.appendChild(customBg);
+
+  const preview = document.createElement('div');
+  preview.id = 'background-preview';
+  bgSection.appendChild(preview);
+
+  container.appendChild(bgSection);
+
+  const bgRadios = radioGroup.querySelectorAll('input');
+
+  const applyBackground = (type, image) => {
+    if (type === 'custom' && image) {
+      preview.style.backgroundImage = `url(${image})`;
+      preview.style.backgroundColor = '';
+    } else if (type === 'none') {
+      preview.style.backgroundImage = '';
+      preview.style.backgroundColor = 'transparent';
+    } else {
+      preview.style.backgroundImage = '';
+      preview.style.backgroundColor = '';
+    }
+  };
+
+  const setBg = (type) => {
+    localStorage.setItem(`${prefix}bgType`, type);
+    if (type !== 'custom') {
+      localStorage.removeItem(`${prefix}bgImage`);
+    }
+    applyBackground(type, localStorage.getItem(`${prefix}bgImage`));
+    customBg.classList.toggle('hidden', type !== 'custom');
+  };
+
+  bgRadios.forEach((radio) => {
+    radio.addEventListener('change', () => setBg(radio.value));
+  });
+
+  fileInput.addEventListener('change', () => {
+    const file = fileInput.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const dataUrl = e.target.result;
+      localStorage.setItem(`${prefix}bgImage`, dataUrl);
+      localStorage.setItem(`${prefix}bgType`, 'custom');
+      radioGroup.querySelector(`input[value="custom"]`).checked = true;
+      applyBackground('custom', dataUrl);
+      customBg.classList.remove('hidden');
+    };
+    reader.readAsDataURL(file);
+  });
+
+  const savedBgType = localStorage.getItem(`${prefix}bgType`) || 'default';
+  const savedBgImage = localStorage.getItem(`${prefix}bgImage`);
+  const initialRadio = radioGroup.querySelector(`input[value="${savedBgType}"]`);
+  if (initialRadio) initialRadio.checked = true;
+  applyBackground(savedBgType, savedBgImage);
+  customBg.classList.toggle('hidden', savedBgType !== 'custom');
+
+  // Chatbubble color section
+  const colorSection = document.createElement('div');
+  colorSection.className = 'section';
+  const colorTitle = document.createElement('h3');
+  colorTitle.textContent = 'Chatbubble Color';
+  colorSection.appendChild(colorTitle);
+
+  const colorPreview = document.createElement('div');
+  colorPreview.className = 'preview';
+  colorSection.appendChild(colorPreview);
+
+  const colorGrid = document.createElement('div');
+  colorGrid.className = 'color-grid';
+  colorSection.appendChild(colorGrid);
+
+  const colors = ['#ffffff', '#ffadad', '#ffd6a5', '#fdffb6', '#caffbf', '#9bf6ff', '#a0c4ff', '#bdb2ff', '#ffc6ff'];
+
+  const setColor = (color) => {
+    localStorage.setItem(`${prefix}bubbleColor`, color);
+    colorPreview.style.backgroundColor = color;
+    Array.from(colorGrid.children).forEach((btn) => {
+      btn.classList.toggle('selected', btn.dataset.color === color);
+    });
+  };
+
+  colors.forEach((c) => {
+    const btn = document.createElement('button');
+    btn.className = 'color-option';
+    btn.style.backgroundColor = c;
+    btn.dataset.color = c;
+    btn.addEventListener('click', () => setColor(c));
+    colorGrid.appendChild(btn);
+  });
+
+  const savedColor = localStorage.getItem(`${prefix}bubbleColor`) || colors[0];
+  setColor(savedColor);
+
+  container.appendChild(colorSection);
+}

--- a/features/crunchyroll.js
+++ b/features/crunchyroll.js
@@ -1,0 +1,3 @@
+export default function init(container) {
+  container.textContent = 'Custom settings for Crunchyroll are coming soon.';
+}

--- a/features/x.js
+++ b/features/x.js
@@ -1,0 +1,3 @@
+export default function init(container) {
+  container.textContent = 'Custom settings for X are coming soon.';
+}

--- a/sidebar.css
+++ b/sidebar.css
@@ -116,3 +116,60 @@
   display: none;
 }
 
+#omora-sidebar .site-settings-panel {
+  padding: 8px;
+  border-top: 1px solid #ccc;
+}
+
+#omora-sidebar.collapsed .site-settings-panel {
+  display: none;
+}
+
+#omora-sidebar .section {
+  margin-bottom: 12px;
+}
+
+#omora-sidebar .radio-group {
+  display: flex;
+  gap: 10px;
+}
+
+#omora-sidebar #custom-bg {
+  margin-top: 8px;
+}
+
+#omora-sidebar #background-preview {
+  margin-top: 8px;
+  width: 100%;
+  height: 100px;
+  border: 1px solid #ccc;
+  background-size: cover;
+  background-position: center;
+}
+
+#omora-sidebar .color-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 24px);
+  gap: 6px;
+  margin-top: 8px;
+}
+
+#omora-sidebar .color-option {
+  width: 24px;
+  height: 24px;
+  border: none;
+  cursor: pointer;
+}
+
+#omora-sidebar .color-option.selected {
+  outline: 2px solid #000;
+}
+
+#omora-sidebar.omora-theme-dark .color-option.selected {
+  outline: 2px solid #fff;
+}
+
+#omora-sidebar .hidden {
+  display: none;
+}
+

--- a/sidebar.js
+++ b/sidebar.js
@@ -62,6 +62,44 @@
 
     window.omoraAddButton = addButton;
 
+    const supportedSites = {
+      chatgpt: { hasAppearanceSettings: true },
+      x: { hasCustomTheme: true },
+      crunchyroll: { hasVideoControls: true }
+    };
+
+    let sitePanel;
+
+    const hostname = window.location.hostname.replace(/^www\./, '');
+    const domainKey = hostname.split('.')[0];
+    const domainLabel = domainKey.charAt(0).toUpperCase() + domainKey.slice(1);
+
+    if (supportedSites[domainKey]) {
+      addButton({
+        icon: '🌐',
+        label: `${domainLabel} Features`,
+        onClick: async (e) => {
+          if (sitePanel) {
+            sitePanel.remove();
+            sitePanel = undefined;
+            return;
+          }
+          sitePanel = document.createElement('div');
+          sitePanel.className = 'site-settings-panel';
+          e.currentTarget.insertAdjacentElement('afterend', sitePanel);
+          try {
+            const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
+            const mod = await import(moduleUrl);
+            if (mod && typeof mod.default === 'function') {
+              mod.default(sitePanel, domainKey);
+            }
+          } catch (err) {
+            sitePanel.textContent = 'Failed to load settings.';
+          }
+        }
+      });
+    }
+
     addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });
 


### PR DESCRIPTION
## Summary
- Show dynamic "Website Features" sidebar button for supported domains
- Add ChatGPT appearance settings panel with per-domain persistence
- Stub X and Crunchyroll feature modules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c81c820083299dee83870450ff4b