### PR TITLE
feat: add website-specific sidebar button

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,5 @@ Minimal Chrome extension.
 - Saved appearance settings are automatically injected into ChatGPT pages
   (https://chat.openai.com/*), applying background and user chat bubble colors
   in real time.
-- When browsing supported sites, a domain-specific button (e.g., "ChatGPT Features")
-  appears in the sidebar and opens a settings panel for that site's custom options.
+- The sidebar detects the active tab's domain and shows a "Website-Specific" button
+  for supported sites, opening a feature panel tailored to that domain.

--- a/sidebar.js
+++ b/sidebar.js
@@ -70,35 +70,45 @@
 
     let sitePanel;
 
-    const hostname = window.location.hostname.replace(/^www\./, '');
-    const domainKey = hostname.split('.')[0];
-    const domainLabel = domainKey.charAt(0).toUpperCase() + domainKey.slice(1);
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs && tabs[0];
+      if (!tab || !tab.url) {
+        return;
+      }
+      try {
+        const url = new URL(tab.url);
+        const hostname = url.hostname.replace(/^www\./, '');
+        const domainKey = hostname.split('.')[0];
 
-    if (supportedSites[domainKey]) {
-      addButton({
-        icon: '🌐',
-        label: `${domainLabel} Features`,
-        onClick: async (e) => {
-          if (sitePanel) {
-            sitePanel.remove();
-            sitePanel = undefined;
-            return;
-          }
-          sitePanel = document.createElement('div');
-          sitePanel.className = 'site-settings-panel';
-          e.currentTarget.insertAdjacentElement('afterend', sitePanel);
-          try {
-            const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
-            const mod = await import(moduleUrl);
-            if (mod && typeof mod.default === 'function') {
-              mod.default(sitePanel, domainKey);
+        if (supportedSites[domainKey]) {
+          addButton({
+            icon: '🌐',
+            label: 'Website-Specific',
+            onClick: async (e) => {
+              if (sitePanel) {
+                sitePanel.remove();
+                sitePanel = undefined;
+                return;
+              }
+              sitePanel = document.createElement('div');
+              sitePanel.className = 'site-settings-panel';
+              e.currentTarget.insertAdjacentElement('afterend', sitePanel);
+              try {
+                const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
+                const mod = await import(moduleUrl);
+                if (mod && typeof mod.default === 'function') {
+                  mod.default(sitePanel, domainKey);
+                }
+              } catch (err) {
+                sitePanel.textContent = 'Failed to load settings.';
+              }
             }
-          } catch (err) {
-            sitePanel.textContent = 'Failed to load settings.';
-          }
+          });
         }
-      });
-    }
+      } catch (err) {
+        // ignore URL parsing errors
+      }
+    });
 
     addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });


### PR DESCRIPTION
## Summary
- use Chrome Tabs API to detect active tab domain and conditionally add a Website-Specific button
- document domain-based button behavior in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ca92da6483298ab3e2756176714c