### PR TITLE
Fix sidebar domain detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,6 @@ Minimal Chrome extension.
 - Saved appearance settings are automatically injected into ChatGPT pages
   (https://chat.openai.com/*), applying background and user chat bubble colors
   in real time.
-- The sidebar detects the active tab's domain and shows a "Website-Specific" button
-  for supported sites, opening a feature panel tailored to that domain.
+- The sidebar detects the current page's domain without relying on the
+  `chrome.tabs` API and shows a "Website-Specific" button for supported
+  sites, opening a feature panel tailored to that domain.

--- a/sidebar.js
+++ b/sidebar.js
@@ -70,45 +70,39 @@
 
     let sitePanel;
 
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const tab = tabs && tabs[0];
-      if (!tab || !tab.url) {
-        return;
-      }
-      try {
-        const url = new URL(tab.url);
-        const hostname = url.hostname.replace(/^www\./, '');
-        const domainKey = hostname.split('.')[0];
+    try {
+      const url = new URL(window.location.href);
+      const hostname = url.hostname.replace(/^www\./, '');
+      const domainKey = hostname.split('.')[0];
 
-        if (supportedSites[domainKey]) {
-          addButton({
-            icon: '🌐',
-            label: 'Website-Specific',
-            onClick: async (e) => {
-              if (sitePanel) {
-                sitePanel.remove();
-                sitePanel = undefined;
-                return;
-              }
-              sitePanel = document.createElement('div');
-              sitePanel.className = 'site-settings-panel';
-              e.currentTarget.insertAdjacentElement('afterend', sitePanel);
-              try {
-                const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
-                const mod = await import(moduleUrl);
-                if (mod && typeof mod.default === 'function') {
-                  mod.default(sitePanel, domainKey);
-                }
-              } catch (err) {
-                sitePanel.textContent = 'Failed to load settings.';
-              }
+      if (supportedSites[domainKey]) {
+        addButton({
+          icon: '🌐',
+          label: 'Website-Specific',
+          onClick: async (e) => {
+            if (sitePanel) {
+              sitePanel.remove();
+              sitePanel = undefined;
+              return;
             }
-          });
-        }
-      } catch (err) {
-        // ignore URL parsing errors
+            sitePanel = document.createElement('div');
+            sitePanel.className = 'site-settings-panel';
+            e.currentTarget.insertAdjacentElement('afterend', sitePanel);
+            try {
+              const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
+              const mod = await import(moduleUrl);
+              if (mod && typeof mod.default === 'function') {
+                mod.default(sitePanel, domainKey);
+              }
+            } catch (err) {
+              sitePanel.textContent = 'Failed to load settings.';
+            }
+          }
+        });
       }
-    });
+    } catch (err) {
+      // ignore URL parsing errors
+    }
 
     addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });


### PR DESCRIPTION
## Summary
- prevent Omora sidebar from crashing by using the page URL instead of the unavailable `chrome.tabs` API
- document updated domain detection in README

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6895cffd60ec8329af45910b7c2d5c8d