### PR TITLE
feat: add chatgpt appearance controls and tidy sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ Minimal Chrome extension.
 - All sidebar text and the chevron icon switch between white and black
   according to the selected theme.
 - Scrollbars inside the sidebar are hidden for a cleaner appearance.
-- "Appearance" settings tab lets you set a custom background image or chat
-  bubble color with live preview and localStorage persistence.
-- Saved appearance settings are automatically injected into ChatGPT pages
-  (https://chat.openai.com/*), applying background and user chat bubble colors
-  in real time.
+- On https://chatgpt.com/* (excluding /codex), the "Website-Specific" panel
+  lets you choose a custom background image or chat bubble color with live
+  preview and chrome.storage persistence.
+- Saved appearance settings are automatically injected into chatgpt.com
+  pages, applying background and user chat bubble colors in real time.
 - The sidebar detects the current page's domain without relying on the
   `chrome.tabs` API and shows a "Website-Specific" button for supported
   sites, opening a feature panel tailored to that domain.

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,12 @@
   "background": { "service_worker": "background.js" },
   "content_scripts": [
     { "matches": ["<all_urls>"], "js": ["sidebar.js"], "css": ["sidebar.css"], "run_at": "document_end" },
-    { "matches": ["https://chat.openai.com/*", "https://chatgpt.com/*"], "js": ["appearanceInjector.js"], "run_at": "document_end" }
+    {
+      "matches": ["https://chatgpt.com/*"],
+      "exclude_matches": ["https://chatgpt.com/codex*"],
+      "js": ["appearanceInjector.js"],
+      "run_at": "document_end"
+    }
   ],
   "action": {
     "default_icon": {

--- a/sidebar.js
+++ b/sidebar.js
@@ -75,7 +75,10 @@
       const hostname = url.hostname.replace(/^www\./, '');
       const domainKey = hostname.split('.')[0];
 
-      if (supportedSites[domainKey]) {
+      if (
+        supportedSites[domainKey] &&
+        !(domainKey === 'chatgpt' && url.pathname.startsWith('/codex'))
+      ) {
         addButton({
           icon: '🌐',
           label: 'Website-Specific',
@@ -92,7 +95,7 @@
               const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
               const mod = await import(moduleUrl);
               if (mod && typeof mod.default === 'function') {
-                mod.default(sitePanel, domainKey);
+                mod.default(sitePanel);
               }
             } catch (err) {
               sitePanel.textContent = 'Failed to load settings.';
@@ -104,7 +107,6 @@
       // ignore URL parsing errors
     }
 
-    addButton({ icon: '🏠', label: 'Home', onClick: () => console.log('Home clicked') });
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });
 
     const computeTheme = () => {
@@ -203,13 +205,6 @@
         buttonConfigs.forEach((cfg) => {
           buttonsContainer.appendChild(createButton(cfg));
         });
-
-        // Neuer Appearance-Button
-        buttonsContainer.appendChild(createButton({
-          icon: '🎨',
-          label: 'Appearance',
-          onClick: () => chrome.runtime.openOptionsPage()
-        }));
 
         bottomButtonConfigs.forEach((cfg) => {
           bottomButtonsContainer.appendChild(createButton(cfg));


### PR DESCRIPTION
## Summary
- remove home and appearance buttons from sidebar
- add ChatGPT-specific appearance settings via Website-Specific panel
- restrict appearance injector to chatgpt.com except /codex

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d25a582c8329aa4726a460bd2964