### PR TITLE
fix: remove dangling feature references

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,3 @@ Minimal Chrome extension.
 - All sidebar text and the chevron icon switch between white and black
   according to the selected theme.
 - Scrollbars inside the sidebar are hidden for a cleaner appearance.
-- On https://chatgpt.com/* (excluding /codex), the "Website-Specific" panel
-  lets you choose a custom background image or chat bubble color with live
-  preview and chrome.storage persistence.
-- Saved appearance settings are automatically injected into chatgpt.com
-  pages, applying background and user chat bubble colors in real time.
-- The sidebar detects the current page's domain without relying on the
-  `chrome.tabs` API and shows a "Website-Specific" button for supported
-  sites, opening a feature panel tailored to that domain.

--- a/manifest.json
+++ b/manifest.json
@@ -11,13 +11,7 @@
   "permissions": ["storage", "tabs"],
   "background": { "service_worker": "background.js" },
   "content_scripts": [
-    { "matches": ["<all_urls>"], "js": ["sidebar.js"], "css": ["sidebar.css"], "run_at": "document_end" },
-    {
-      "matches": ["https://chatgpt.com/*"],
-      "exclude_matches": ["https://chatgpt.com/codex*"],
-      "js": ["appearanceInjector.js"],
-      "run_at": "document_end"
-    }
+    { "matches": ["<all_urls>"], "js": ["sidebar.js"], "css": ["sidebar.css"], "run_at": "document_end" }
   ],
   "action": {
     "default_icon": {
@@ -26,6 +20,5 @@
       "128": "public/icon128.png"
     },
     "default_title": "Omora"
-  },
-  "options_page": "settingsAppearance.html"
+  }
 }

--- a/sidebar.js
+++ b/sidebar.js
@@ -62,51 +62,6 @@
 
     window.omoraAddButton = addButton;
 
-    const supportedSites = {
-      chatgpt: { hasAppearanceSettings: true },
-      x: { hasCustomTheme: true },
-      crunchyroll: { hasVideoControls: true }
-    };
-
-    let sitePanel;
-
-    try {
-      const url = new URL(window.location.href);
-      const hostname = url.hostname.replace(/^www\./, '');
-      const domainKey = hostname.split('.')[0];
-
-      if (
-        supportedSites[domainKey] &&
-        !(domainKey === 'chatgpt' && url.pathname.startsWith('/codex'))
-      ) {
-        addButton({
-          icon: '🌐',
-          label: 'Website-Specific',
-          onClick: async (e) => {
-            if (sitePanel) {
-              sitePanel.remove();
-              sitePanel = undefined;
-              return;
-            }
-            sitePanel = document.createElement('div');
-            sitePanel.className = 'site-settings-panel';
-            e.currentTarget.insertAdjacentElement('afterend', sitePanel);
-            try {
-              const moduleUrl = chrome.runtime.getURL(`features/${domainKey}.js`);
-              const mod = await import(moduleUrl);
-              if (mod && typeof mod.default === 'function') {
-                mod.default(sitePanel);
-              }
-            } catch (err) {
-              sitePanel.textContent = 'Failed to load settings.';
-            }
-          }
-        });
-      }
-    } catch (err) {
-      // ignore URL parsing errors
-    }
-
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });
 
     const computeTheme = () => {


### PR DESCRIPTION
## Summary
- remove website-specific logic and references to deleted scripts
- update manifest to only include sidebar script
- document current sidebar features

## Testing
- `node --check background.js`
- `node --check sidebar.js`
- `python -m json.tool manifest.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6895d600ff588329b9ded2dd0c138a6b