### PR TITLE
feat: add website-specific button scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Minimal Chrome extension.
 - Scaffold for sidebar buttons. Buttons show their icon and label when
   the sidebar exceeds 100px and collapse to icons only when narrower.
   New buttons can be added at runtime via `window.omoraAddButton`.
+- Website-specific buttons. Each site can provide its own button
+  configuration through scripts in `buttons/website-specific`. The first
+  implementation adds a ChatGPT button on `chatgpt.com`.
 - Expand/Collapse toggle button at the top. It animates the sidebar
   width between 50px and 200px over 0.5s, shows a "Collaps" label when
   expanded, and rotates its chevron icon 180° to indicate the state.

--- a/buttons/website-specific/chatgpt.js
+++ b/buttons/website-specific/chatgpt.js
@@ -1,0 +1,14 @@
+(() => {
+  const config = {
+    icon: '🤖',
+    label: 'ChatGPT',
+    onClick: () => console.log('ChatGPT-specific action'),
+  };
+
+  if (window.omoraAddButton) {
+    window.omoraAddButton(config);
+  } else {
+    window.omoraPendingButtons = window.omoraPendingButtons || [];
+    window.omoraPendingButtons.push(config);
+  }
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
   "permissions": ["storage", "tabs"],
   "background": { "service_worker": "background.js" },
   "content_scripts": [
-    { "matches": ["<all_urls>"], "js": ["sidebar.js"], "css": ["sidebar.css"], "run_at": "document_end" }
+    { "matches": ["<all_urls>"], "js": ["sidebar.js"], "css": ["sidebar.css"], "run_at": "document_end" },
+    { "matches": ["https://chatgpt.com/*"], "js": ["buttons/website-specific/chatgpt.js"], "run_at": "document_end" }
   ],
   "action": {
     "default_icon": {

--- a/sidebar.js
+++ b/sidebar.js
@@ -62,6 +62,11 @@
 
     window.omoraAddButton = addButton;
 
+    if (Array.isArray(window.omoraPendingButtons)) {
+      window.omoraPendingButtons.forEach(addButton);
+      window.omoraPendingButtons = [];
+    }
+
     addButton({ icon: '⚙️', label: 'Settings', onClick: () => console.log('Settings clicked'), position: 'bottom' });
 
     const computeTheme = () => {


### PR DESCRIPTION
## Summary
- add infrastructure for website-specific buttons and queue support
- include ChatGPT example button
- document website-specific button setup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d7ab573c8329a1c17985ffcfef05