### PR TITLE
Add color picker sidebar tool with eyedropper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Minimal Chrome extension.
 - Clicking an icon expands a content panel to the left starting at 300px. The panel can be resized horizontally while the icon strip remains fixed.
 - Smooth animation for expanding and collapsing. Clicking the active icon closes the panel; selecting another icon swaps the panel content without collapsing.
 - New buttons can be added at runtime via `window.omoraAddButton`.
+- Built-in Color Picker with saturation/value square, hue slider, HEX and RGB fields, copy buttons, eyedropper, and persistent last color.
 - Website-specific buttons. Each site can provide its own button configuration through scripts in `buttons/website-specific`. The ChatGPT implementation adds a button on `chatgpt.com` that opens a settings menu where users can switch between no background, the default image, or a custom uploaded picture, and choose chat bubble colors from a grid of swatches.
 - A persistent Settings button is anchored to the bottom of the icon strip.
 - Styling for the sidebar lives in a dedicated `sidebar.css` file for easier customization.

--- a/sidebar.css
+++ b/sidebar.css
@@ -14,7 +14,7 @@
   width: 0;
   overflow: auto;
   background: var(--omora-panel-bg);
-  transition: width 0.3s ease;
+  transition: width 0.2s ease;
   position: relative;
 }
 
@@ -86,4 +86,78 @@
 #omora-sidebar {
   scrollbar-width: none;
   -ms-overflow-style: none;
+}
+
+#omora-sidebar .color-picker {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#omora-sidebar .color-picker .cp-sv {
+  position: relative;
+  width: 100%;
+  height: 150px;
+  background: hsl(0, 100%, 50%);
+  background-image: linear-gradient(to top, black, transparent), linear-gradient(to right, white, transparent);
+  cursor: crosshair;
+}
+
+#omora-sidebar .color-picker .cp-cursor {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  box-sizing: border-box;
+  transform: translate(-5px, -5px);
+}
+
+#omora-sidebar .color-picker .cp-hue {
+  width: 100%;
+  appearance: none;
+  height: 12px;
+  background: linear-gradient(to right, red, yellow, lime, aqua, blue, magenta, red);
+  cursor: pointer;
+}
+
+#omora-sidebar .color-picker .cp-preview {
+  width: 40px;
+  height: 40px;
+  border: 1px solid;
+}
+
+#omora-sidebar .color-picker .row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+#omora-sidebar .color-picker input[type="text"] {
+  flex: 1;
+  padding: 4px;
+  border: 1px solid;
+  background: transparent;
+  color: inherit;
+}
+
+#omora-sidebar .color-picker button {
+  padding: 4px;
+  border: 1px solid;
+  background: var(--omora-bg);
+  color: inherit;
+  cursor: pointer;
+}
+
+.omora-theme-dark #omora-sidebar .color-picker input[type="text"],
+.omora-theme-dark #omora-sidebar .color-picker button,
+.omora-theme-dark #omora-sidebar .color-picker .cp-preview {
+  border-color: #555;
+}
+
+.omora-theme-light #omora-sidebar .color-picker input[type="text"],
+.omora-theme-light #omora-sidebar .color-picker button,
+.omora-theme-light #omora-sidebar .color-picker .cp-preview {
+  border-color: #ccc;
 }

--- a/sidebar.js
+++ b/sidebar.js
@@ -13,6 +13,8 @@
     let mediaQuery;
     let startX = 0;
     let startWidth = 0;
+    let isEyedropperActive = false;
+    let cancelEyedropper;
 
     const buttonConfigs = [];
     const bottomButtonConfigs = [];
@@ -62,6 +64,16 @@
         activeBtn = undefined;
       }
     };
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        if (isEyedropperActive) {
+          if (typeof cancelEyedropper === 'function') cancelEyedropper();
+        } else {
+          closePanel();
+        }
+      }
+    });
 
     const addButton = (config) => {
       const list = config.position === 'bottom' ? bottomButtonConfigs : buttonConfigs;
@@ -175,6 +187,203 @@
       } else if (message.sidebarVisible === false) {
         hideSidebar();
       }
+    });
+
+    const createColorPicker = () => {
+      const root = document.createElement('div');
+      root.className = 'color-picker';
+      const sv = document.createElement('div');
+      sv.className = 'cp-sv';
+      const cursor = document.createElement('div');
+      cursor.className = 'cp-cursor';
+      sv.appendChild(cursor);
+      const hue = document.createElement('input');
+      hue.type = 'range';
+      hue.className = 'cp-hue';
+      hue.min = '0';
+      hue.max = '360';
+      const rowPrev = document.createElement('div');
+      rowPrev.className = 'row';
+      const preview = document.createElement('div');
+      preview.className = 'cp-preview';
+      const eyeBtn = document.createElement('button');
+      eyeBtn.innerHTML = '<svg viewBox="0 0 24 24" width="16" height="16"><path fill="currentColor" d="M20.71 5.63l-2.34-2.34a1 1 0 00-1.41 0L11 9.25l-4.96-4.96a1 1 0 00-1.41 0L2.29 6.29a1 1 0 000 1.41L7.25 12l-4.96 4.96a1 1 0 000 1.41l2.34 2.34a1 1 0 001.41 0L11 14.75l4.96 4.96a1 1 0 001.41 0l2.34-2.34a1 1 0 000-1.41L14.75 12l4.96-4.96a1 1 0 000-1.41z"/></svg>';
+      rowPrev.appendChild(preview);
+      rowPrev.appendChild(eyeBtn);
+      const rowHex = document.createElement('div');
+      rowHex.className = 'row';
+      const hexInput = document.createElement('input');
+      hexInput.type = 'text';
+      hexInput.className = 'cp-hex';
+      hexInput.maxLength = 7;
+      const hexBtn = document.createElement('button');
+      hexBtn.textContent = 'Copy HEX';
+      rowHex.appendChild(hexInput);
+      rowHex.appendChild(hexBtn);
+      const rowRgb = document.createElement('div');
+      rowRgb.className = 'row';
+      const rgbInput = document.createElement('input');
+      rgbInput.type = 'text';
+      rgbInput.className = 'cp-rgb';
+      const rgbBtn = document.createElement('button');
+      rgbBtn.textContent = 'Copy RGB';
+      rowRgb.appendChild(rgbInput);
+      rowRgb.appendChild(rgbBtn);
+      root.appendChild(sv);
+      root.appendChild(hue);
+      root.appendChild(rowPrev);
+      root.appendChild(rowHex);
+      root.appendChild(rowRgb);
+      let h = 0;
+      let s = 1;
+      let v = 1;
+      const clamp = (n, min, max) => Math.min(Math.max(n, min), max);
+      const rgbToHex = (r, g, b) => '#' + [r, g, b].map(x => x.toString(16).padStart(2, '0')).join('');
+      const hexToRgb = (hex) => {
+        const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+        if (!m) return;
+        const int = parseInt(m[1], 16);
+        return [(int >> 16) & 255, (int >> 8) & 255, int & 255];
+      };
+      const rgbToHsv = (r, g, b) => {
+        r /= 255;
+        g /= 255;
+        b /= 255;
+        const max = Math.max(r, g, b);
+        const min = Math.min(r, g, b);
+        const d = max - min;
+        let hh;
+        if (d === 0) hh = 0; else if (max === r) hh = ((g - b) / d + (g < b ? 6 : 0)) * 60; else if (max === g) hh = ((b - r) / d + 2) * 60; else hh = ((r - g) / d + 4) * 60;
+        const ss = max === 0 ? 0 : d / max;
+        return [hh, ss, max];
+      };
+      const hsvToRgb = (hh, ss, vv) => {
+        const c = vv * ss;
+        const x = c * (1 - Math.abs((hh / 60) % 2 - 1));
+        const m = vv - c;
+        let r, g, b;
+        if (hh < 60) [r, g, b] = [c, x, 0];
+        else if (hh < 120) [r, g, b] = [x, c, 0];
+        else if (hh < 180) [r, g, b] = [0, c, x];
+        else if (hh < 240) [r, g, b] = [0, x, c];
+        else if (hh < 300) [r, g, b] = [x, 0, c];
+        else [r, g, b] = [c, 0, x];
+        return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+      };
+      const update = () => {
+        const rgb = hsvToRgb(h, s, v);
+        const hex = rgbToHex(rgb[0], rgb[1], rgb[2]);
+        preview.style.background = hex;
+        hexInput.value = hex;
+        rgbInput.value = rgb.join(',');
+        sv.style.background = `hsl(${h}, 100%, 50%)`;
+        cursor.style.left = s * 100 + '%';
+        cursor.style.top = (1 - v) * 100 + '%';
+        hue.value = h;
+        localStorage.setItem('omoraColorPickerColor', hex);
+      };
+      const setColor = (hex) => {
+        const rgb = hexToRgb(hex);
+        if (!rgb) return;
+        const hsv = rgbToHsv(rgb[0], rgb[1], rgb[2]);
+        h = hsv[0];
+        s = hsv[1];
+        v = hsv[2];
+        update();
+      };
+      const onSv = (e) => {
+        const rect = sv.getBoundingClientRect();
+        s = clamp((e.clientX - rect.left) / rect.width, 0, 1);
+        v = 1 - clamp((e.clientY - rect.top) / rect.height, 0, 1);
+        update();
+      };
+      sv.addEventListener('mousedown', (e) => {
+        onSv(e);
+        const move = (ev) => onSv(ev);
+        const up = () => {
+          document.removeEventListener('mousemove', move);
+          document.removeEventListener('mouseup', up);
+        };
+        document.addEventListener('mousemove', move);
+        document.addEventListener('mouseup', up);
+      });
+      hue.addEventListener('input', () => {
+        h = parseFloat(hue.value);
+        update();
+      });
+      hexInput.addEventListener('input', () => setColor(hexInput.value));
+      rgbInput.addEventListener('input', () => {
+        const parts = rgbInput.value.split(',').map((n) => parseInt(n.trim(), 10));
+        if (parts.length === 3 && parts.every((n) => !isNaN(n) && n >= 0 && n <= 255)) setColor(rgbToHex(parts[0], parts[1], parts[2]));
+      });
+      hexBtn.addEventListener('click', () => navigator.clipboard.writeText(hexInput.value));
+      rgbBtn.addEventListener('click', () => navigator.clipboard.writeText(rgbInput.value));
+      eyeBtn.addEventListener('click', () => {
+        if (isEyedropperActive) return;
+        if (window.EyeDropper) {
+          const controller = new AbortController();
+          cancelEyedropper = () => controller.abort();
+          isEyedropperActive = true;
+          new window.EyeDropper().open({ signal: controller.signal }).then(({ sRGBHex }) => setColor(sRGBHex)).catch(() => {}).finally(() => {
+            isEyedropperActive = false;
+            cancelEyedropper = undefined;
+          });
+        } else {
+          isEyedropperActive = true;
+          navigator.mediaDevices.getDisplayMedia({ video: true }).then((stream) => {
+            const video = document.createElement('video');
+            video.srcObject = stream;
+            video.style.position = 'absolute';
+            video.style.top = '0';
+            video.style.left = '0';
+            video.style.width = '100%';
+            video.style.height = '100%';
+            video.play();
+            const overlay = document.createElement('div');
+            overlay.style.position = 'fixed';
+            overlay.style.top = '0';
+            overlay.style.left = '0';
+            overlay.style.right = '0';
+            overlay.style.bottom = '0';
+            overlay.style.cursor = 'crosshair';
+            overlay.style.zIndex = '2147483647';
+            overlay.appendChild(video);
+            document.body.appendChild(overlay);
+            const canvas = document.createElement('canvas');
+            const stop = () => {
+              stream.getTracks().forEach((t) => t.stop());
+              overlay.remove();
+              isEyedropperActive = false;
+              cancelEyedropper = undefined;
+            };
+            cancelEyedropper = stop;
+            overlay.addEventListener('click', (ev) => {
+              const rect = overlay.getBoundingClientRect();
+              canvas.width = video.videoWidth;
+              canvas.height = video.videoHeight;
+              const ctx = canvas.getContext('2d');
+              ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+              const x = Math.round(ev.clientX * canvas.width / rect.width);
+              const y = Math.round(ev.clientY * canvas.height / rect.height);
+              const data = ctx.getImageData(x, y, 1, 1).data;
+              setColor(rgbToHex(data[0], data[1], data[2]));
+              stop();
+            });
+          }).catch(() => {
+            isEyedropperActive = false;
+            cancelEyedropper = undefined;
+          });
+        }
+      });
+      const saved = localStorage.getItem('omoraColorPickerColor');
+      setColor(saved || '#ff0000');
+      return root;
+    };
+
+    addButton({
+      icon: '🎨',
+      label: 'Color Picker',
+      content: createColorPicker,
     });
 
     addButton({


### PR DESCRIPTION
## Summary
- add color picker tool with saturation/value square, hue slider, hex and rgb fields, and copy buttons
- support screen eyedropper with ESC to cancel and remember last color
- update panel transition and styling for color picker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ec4009cc8329b6dab82e6d069360