### PR TITLE
Fix sidebar toggle and add dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Minimal Chrome extension.
 - Fixed 30px icon bar with tooltips
 - Resizable 200ms animated tool panel
 - Built-in Color Picker plugin storing the last color
-- Automatic light and dark theme selection
+- Toggle sidebar by clicking the Omora extension icon
+- Dark themed sidebar
 
 ## Development
 

--- a/core/SidebarManager.js
+++ b/core/SidebarManager.js
@@ -6,6 +6,7 @@ export class SidebarManager {
     this.panelWidth = isNaN(saved) ? 300 : saved
     this.container = document.createElement('div')
     this.container.id = 'omora-sidebar'
+    this.container.style.display = 'none'
     this.panel = document.createElement('div')
     this.panel.className = 'omora-panel'
     this.panel.style.width = '0px'

--- a/sidebar.js
+++ b/sidebar.js
@@ -3,8 +3,18 @@
   Promise.all([
     import(getURL('core/SidebarManager.js')),
     import(getURL('tools/index.js'))
-  ]).then(([core, tools]) => {
+  ]).then(async ([core, tools]) => {
+    window.omoraForceTheme = 'dark'
     const manager = new core.SidebarManager()
     tools.registerAllTools(manager)
+    manager.container.style.display = 'none'
+    chrome.runtime.onMessage.addListener(message => {
+      if (typeof message.sidebarVisible !== 'undefined') {
+        manager.container.style.display = message.sidebarVisible ? 'flex' : 'none'
+        if (!message.sidebarVisible) manager.closeActiveTool()
+      }
+    })
+    const { sidebarVisible = false } = await chrome.storage.local.get('sidebarVisible')
+    if (sidebarVisible) manager.container.style.display = 'flex'
   }).catch(() => {})
 })()


### PR DESCRIPTION
## Summary
- Toggle sidebar visibility when extension icon is clicked
- Default the sidebar to a dark theme
- Document new sidebar toggle and dark theme features

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f273c61083299ad4e3540df9fbf8