### PR TITLE
Fix sidebar tool activation and registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Minimal Chrome extension.
 - Fixed 30px icon bar with tooltips
 - Resizable 200ms animated tool panel
 - Built-in Color Picker plugin storing the last color
+- Tool panels open on icon click and run their tools
 - Toggle sidebar by clicking the Omora extension icon
 - Dark themed sidebar
 
 ## Development
 
-Tools live in `tools/<ToolName>` and implement the `OmoraTool` interface. The `SidebarManager` handles tool registration and panel display. Register tools in `tools/index.ts` and initialize the manager in `sidebar.js`.
+Tools live in `tools/<ToolName>` and implement the `OmoraTool` interface. The `SidebarManager` handles tool registration and panel display. Register tools in `tools/index.ts` and the manager is created and all tools are registered at startup in `sidebar.js`.

--- a/core/SidebarManager.js
+++ b/core/SidebarManager.js
@@ -6,8 +6,8 @@ export class SidebarManager {
     this.panelWidth = isNaN(saved) ? 300 : saved
     this.container = document.createElement('div')
     this.container.id = 'omora-sidebar'
-    this.container.style.display = 'none'
     this.panel = document.createElement('div')
+    this.panel.id = 'sidebar-panel-container'
     this.panel.className = 'omora-panel'
     this.panel.style.width = '0px'
     this.resizeHandle = document.createElement('div')
@@ -28,24 +28,34 @@ export class SidebarManager {
     })
   }
   registerTool(tool) {
-    const btn = document.createElement('button')
-    btn.className = 'omora-btn'
-    btn.innerHTML = tool.icon
-    btn.title = tool.tooltip
-    btn.addEventListener('click', () => this.toggle(tool.id))
-    this.iconsTop.appendChild(btn)
-    this.tools.set(tool.id, { tool, button: btn })
+    const icon = document.createElement('button')
+    icon.className = 'omora-btn'
+    icon.innerHTML = tool.icon
+    icon.title = tool.tooltip
+    icon.addEventListener('click', () => this.toggleTool(tool.id))
+    this.iconsTop.appendChild(icon)
+    this.tools.set(tool.id, { tool, button: icon })
   }
-  toggle(id) {
+  toggleTool(id) {
     if (this.activeId === id) {
       this.closeActiveTool()
       return
     }
-    if (this.activeId) this.closeActiveTool()
     const entry = this.tools.get(id)
     if (!entry) return
+    if (this.activeId) this.closeActiveTool()
     this.activeId = id
     entry.button.classList.add('active')
+    let container = document.querySelector('#sidebar-panel-container')
+    if (!container) {
+      container = document.createElement('div')
+      container.id = 'sidebar-panel-container'
+      container.className = 'omora-panel'
+      container.style.width = '0px'
+      container.appendChild(this.resizeHandle)
+      this.container.insertBefore(container, this.container.firstChild)
+    }
+    this.panel = container
     this.panel.innerHTML = ''
     this.panel.appendChild(this.resizeHandle)
     entry.tool.execute(this.panel)

--- a/core/SidebarManager.ts
+++ b/core/SidebarManager.ts
@@ -7,7 +7,7 @@ interface ToolEntry {
 
 export class SidebarManager {
   private tools: Map<string, ToolEntry> = new Map()
-  private container: HTMLElement
+  container: HTMLElement
   private panel: HTMLElement
   private iconsTop: HTMLElement
   private resizeHandle: HTMLElement
@@ -20,6 +20,7 @@ export class SidebarManager {
     this.container = document.createElement('div')
     this.container.id = 'omora-sidebar'
     this.panel = document.createElement('div')
+    this.panel.id = 'sidebar-panel-container'
     this.panel.className = 'omora-panel'
     this.panel.style.width = '0px'
     this.resizeHandle = document.createElement('div')
@@ -41,25 +42,35 @@ export class SidebarManager {
   }
 
   registerTool(tool: OmoraTool) {
-    const btn = document.createElement('button')
-    btn.className = 'omora-btn'
-    btn.innerHTML = tool.icon
-    btn.title = tool.tooltip
-    btn.addEventListener('click', () => this.toggle(tool.id))
-    this.iconsTop.appendChild(btn)
-    this.tools.set(tool.id, { tool, button: btn })
+    const icon = document.createElement('button')
+    icon.className = 'omora-btn'
+    icon.innerHTML = tool.icon
+    icon.title = tool.tooltip
+    icon.addEventListener('click', () => this.toggleTool(tool.id))
+    this.iconsTop.appendChild(icon)
+    this.tools.set(tool.id, { tool, button: icon })
   }
 
-  private toggle(id: string) {
+  private toggleTool(id: string) {
     if (this.activeId === id) {
       this.closeActiveTool()
       return
     }
-    if (this.activeId) this.closeActiveTool()
     const entry = this.tools.get(id)
     if (!entry) return
+    if (this.activeId) this.closeActiveTool()
     this.activeId = id
     entry.button.classList.add('active')
+    let container = document.querySelector('#sidebar-panel-container') as HTMLElement | null
+    if (!container) {
+      container = document.createElement('div')
+      container.id = 'sidebar-panel-container'
+      container.className = 'omora-panel'
+      container.style.width = '0px'
+      container.appendChild(this.resizeHandle)
+      this.container.insertBefore(container, this.container.firstChild)
+    }
+    this.panel = container
     this.panel.innerHTML = ''
     this.panel.appendChild(this.resizeHandle)
     entry.tool.execute(this.panel)
@@ -67,7 +78,7 @@ export class SidebarManager {
     this.panel.style.width = this.panelWidth + 'px'
   }
 
-  private closeActiveTool() {
+  closeActiveTool() {
     if (!this.activeId) return
     const entry = this.tools.get(this.activeId)
     if (entry) {

--- a/sidebar.js
+++ b/sidebar.js
@@ -5,16 +5,16 @@
     import(getURL('tools/index.js'))
   ]).then(async ([core, tools]) => {
     window.omoraForceTheme = 'dark'
-    const manager = new core.SidebarManager()
-    tools.registerAllTools(manager)
-    manager.container.style.display = 'none'
+    const sidebarManager = new core.SidebarManager()
+    tools.registerAllTools(sidebarManager)
+    sidebarManager.container.style.display = 'none'
     chrome.runtime.onMessage.addListener(message => {
       if (typeof message.sidebarVisible !== 'undefined') {
-        manager.container.style.display = message.sidebarVisible ? 'flex' : 'none'
-        if (!message.sidebarVisible) manager.closeActiveTool()
+        sidebarManager.container.style.display = message.sidebarVisible ? 'flex' : 'none'
+        if (!message.sidebarVisible) sidebarManager.closeActiveTool()
       }
     })
     const { sidebarVisible = false } = await chrome.storage.local.get('sidebarVisible')
-    if (sidebarVisible) manager.container.style.display = 'flex'
+    if (sidebarVisible) sidebarManager.container.style.display = 'flex'
   }).catch(() => {})
 })()


### PR DESCRIPTION
## Summary
- ensure SidebarManager registers tools and toggles panels on click
- create panel container when missing and execute tools
- call registerAllTools at startup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f578586c8329ba60feef1bc34c24