### PR TITLE
fix: expose resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Minimal Chrome extension.
 - Tool panels open on icon click and run their tools
 - Toggle sidebar by clicking the Omora extension icon
 - Dark themed sidebar
+- Sidebar resources exposed via `web_accessible_resources` so the extension opens correctly
 
 ## Development
 
 Tools live in `tools/<ToolName>` and implement the `OmoraTool` interface. The `SidebarManager` handles tool registration and panel display. Register tools in `tools/index.ts` and the manager is created and all tools are registered at startup in `sidebar.js`.
+Ensure any modules or styles loaded with `chrome.runtime.getURL` are declared under `web_accessible_resources` in `manifest.json`.

--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,12 @@
     { "matches": ["<all_urls>"], "js": ["sidebar.js"], "css": ["sidebar.css"], "run_at": "document_end" },
     { "matches": ["https://chatgpt.com/*"], "js": ["buttons/website-specific/chatgpt.js"], "run_at": "document_end" }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": ["core/*.js", "tools/**/*.js", "tools/**/*.css"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "action": {
     "default_icon": {
       "16": "public/icon16.png",


### PR DESCRIPTION
## Summary
- expose sidebar modules and styles via `web_accessible_resources` so the extension loads when clicked
- document the new requirement in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a41f7d0a548329a76993637b5a758c