### PR TITLE
Improve rail icons and tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@ The side panel UI is written in TypeScript. It presents a fixed rail on the righ
 
 ## Styling
 Core styles provide a dark theme with system UI fonts, an icon rail, and a collapsible panel. Components animate with 180ms transitions and include focus rings for accessibility.
+
+## Rail Icons
+The rail now uses semantic toolbar and button elements. Each icon button exposes a native tooltip and ARIA label, and the active
+icon is highlighted with a subtle accent background and left border glow.

--- a/src/ui/rail.js
+++ b/src/ui/rail.js
@@ -1,15 +1,19 @@
 export function initRail(container, features) {
+  container.setAttribute('role', 'toolbar')
   features.forEach(feature => {
     const button = document.createElement('button')
     button.className = 'om-rail__icon'
-    button.setAttribute('aria-label', feature.tooltip ?? feature.name)
+    button.dataset.id = feature.id
+    const label = feature.tooltip ?? feature.name
+    button.setAttribute('aria-label', label)
+    button.title = label
     const img = document.createElement('img')
     img.src = chrome.runtime.getURL(`src/features/${feature.id}/${feature.icon}`)
     img.alt = feature.name
     button.appendChild(img)
     button.addEventListener('click', () => {
-      container.querySelectorAll('.om-rail__icon').forEach(b => b.classList.remove('om-rail__icon--active'))
-      button.classList.add('om-rail__icon--active')
+      container.querySelectorAll('.om-rail__icon').forEach(b => b.classList.remove('is-active'))
+      button.classList.add('is-active')
       const ev = new CustomEvent('omora:select', { detail: { feature } })
       container.dispatchEvent(ev)
     })

--- a/src/ui/rail.ts
+++ b/src/ui/rail.ts
@@ -1,17 +1,21 @@
 import type { Feature } from './app.js'
 
 export function initRail(container: HTMLDivElement, features: Feature[]) {
+  container.setAttribute('role', 'toolbar')
   features.forEach(feature => {
     const button = document.createElement('button')
     button.className = 'om-rail__icon'
-    button.setAttribute('aria-label', feature.tooltip ?? feature.name)
+    button.dataset.id = feature.id
+    const label = feature.tooltip ?? feature.name
+    button.setAttribute('aria-label', label)
+    button.title = label
     const img = document.createElement('img')
     img.src = chrome.runtime.getURL(`src/features/${feature.id}/${feature.icon}`)
     img.alt = feature.name
     button.appendChild(img)
     button.addEventListener('click', () => {
-      container.querySelectorAll('.om-rail__icon').forEach(b => b.classList.remove('om-rail__icon--active'))
-      button.classList.add('om-rail__icon--active')
+      container.querySelectorAll('.om-rail__icon').forEach(b => b.classList.remove('is-active'))
+      button.classList.add('is-active')
       const ev = new CustomEvent('omora:select', { detail: { feature } })
       container.dispatchEvent(ev)
     })

--- a/styles/core.css
+++ b/styles/core.css
@@ -35,7 +35,7 @@ body {
   background: transparent;
   border-radius: var(--om-radius-m, 8px);
   cursor: pointer;
-  transition: background 0.18s ease, filter 0.18s ease;
+  transition: background 0.18s ease, filter 0.18s ease, box-shadow 0.18s ease;
 }
 
 .om-rail__icon:hover {
@@ -67,6 +67,16 @@ body {
 .om-rail__icon:active img,
 .om-rail__icon:active svg {
   filter: brightness(0.8);
+}
+
+.om-rail__icon.is-active {
+  background: rgba(59, 130, 246, 0.15);
+  box-shadow: inset 2px 0 0 var(--om-color-accent, #3b82f6);
+}
+
+.om-rail__icon.is-active img,
+.om-rail__icon.is-active svg {
+  filter: brightness(1.2);
 }
 
 .om-shell {


### PR DESCRIPTION
## Summary
- make rail a toolbar and expose button data-id, titles, and ARIA labels
- highlight active rail icon with accent background and left border
- document rail icon behavior and accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43956ec488329b676c4d4aa2d05ea