### PR TITLE
feat: add header component and collapse shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 Omora Chrome extension.
 
 ## Development
-The side panel UI is written in TypeScript. It presents a fixed rail on the right and a content shell on the left with a header showing the active feature name and a close button. The panel can collapse to leave only the rail visible and this state persists in `chrome.storage.local`.
+The side panel UI is written in TypeScript. It presents a fixed rail on the right and a content shell on the left. A dynamic header is created in code with an `#om-title` span and `#om-close` button. Clicking close collapses the shell to leave only the rail visible and the collapsed state persists in `chrome.storage.local`.
+
+### Keyboard Shortcuts
+- **Ctrl+Shift+O** toggles the panel.
+- **Ctrl+Alt+DigitN** focuses and activates the Nth feature in the rail.
 
 ## Styling
 Core styles provide a dark theme with system UI fonts, an icon rail, and a collapsible panel. Components animate with 180ms transitions and include focus rings for accessibility.

--- a/src/ui/app.ts
+++ b/src/ui/app.ts
@@ -1,6 +1,7 @@
 import { loadRegistry } from '../core/registry.js'
 import { initRail } from './rail.js'
 import { loadFeature } from './loader.js'
+import { buildHeader, setTitle } from './header.js'
 
 type Feature = { id: string; name: string; icon: string; tooltip?: string; entry: { html: string } }
 
@@ -18,30 +19,57 @@ async function init() {
   const rail = document.querySelector('.om-rail') as HTMLDivElement
   const shell = document.querySelector('.om-shell') as HTMLDivElement
   const panel = document.querySelector('.om-panel') as HTMLDivElement
-  const title = document.getElementById('om-title') as HTMLSpanElement
-  const close = document.getElementById('om-close') as HTMLButtonElement
+  const header = buildHeader()
+  shell.insertBefore(header, panel)
+  const close = header.querySelector('#om-close') as HTMLButtonElement
+
   const collapse = () => {
-    shell.style.display = 'none'
-    title.textContent = ''
-    const active = rail.querySelector('.om-rail__icon--active') as HTMLButtonElement | null
-    if (active) active.classList.remove('om-rail__icon--active')
+    document.body.classList.add('om-collapsed')
     setState(true)
   }
+
   const expand = () => {
-    shell.style.display = ''
+    document.body.classList.remove('om-collapsed')
     setState(false)
   }
+
+  const toggle = () => {
+    document.body.classList.contains('om-collapsed') ? expand() : collapse()
+  }
+
   const features = (await loadRegistry()) as Feature[]
   initRail(rail, features)
+
   rail.addEventListener('omora:select', e => {
     const feature = (e as CustomEvent).detail.feature as Feature
     loadFeature(panel, feature)
     expand()
   })
+
   close.addEventListener('click', () => collapse())
+
   document.addEventListener('omora:feature-activated', e => {
-    title.textContent = (e as CustomEvent).detail.name ?? ''
+    setTitle((e as CustomEvent).detail.name ?? '')
   })
+
+  document.addEventListener('keydown', e => {
+    if (e.ctrlKey && e.shiftKey && e.code === 'KeyO') {
+      e.preventDefault()
+      toggle()
+    } else if (e.ctrlKey && e.altKey && e.code.startsWith('Digit')) {
+      const index = parseInt(e.code.slice(5), 10) - 1
+      if (index >= 0) {
+        const buttons = Array.from(rail.querySelectorAll<HTMLButtonElement>('.om-rail__icon'))
+        const btn = buttons[index]
+        if (btn) {
+          e.preventDefault()
+          btn.focus()
+          btn.click()
+        }
+      }
+    }
+  })
+
   const state = await getState()
   state?.collapsed ? collapse() : expand()
 }

--- a/src/ui/header.js
+++ b/src/ui/header.js
@@ -1,0 +1,20 @@
+let titleEl;
+export function setTitle(text) {
+  if (titleEl) {
+    titleEl.textContent = text;
+  }
+}
+export function buildHeader() {
+  const header = document.createElement('div');
+  header.className = 'om-header';
+  const title = document.createElement('span');
+  title.id = 'om-title';
+  title.className = 'om-title';
+  titleEl = title;
+  const close = document.createElement('button');
+  close.id = 'om-close';
+  close.className = 'om-close';
+  close.setAttribute('aria-label', 'Close');
+  header.append(title, close);
+  return header;
+}

--- a/src/ui/header.ts
+++ b/src/ui/header.ts
@@ -1,0 +1,25 @@
+let titleEl: HTMLSpanElement
+
+export function setTitle(text: string) {
+  if (titleEl) {
+    titleEl.textContent = text
+  }
+}
+
+export function buildHeader() {
+  const header = document.createElement('div')
+  header.className = 'om-header'
+
+  const title = document.createElement('span')
+  title.id = 'om-title'
+  title.className = 'om-title'
+  titleEl = title
+
+  const close = document.createElement('button')
+  close.id = 'om-close'
+  close.className = 'om-close'
+  close.setAttribute('aria-label', 'Close')
+
+  header.append(title, close)
+  return header
+}

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -10,10 +10,6 @@
     <div id="app">
       <div class="om-rail"></div>
       <div class="om-shell">
-        <div class="om-header">
-          <span id="om-title"></span>
-          <button id="om-close" aria-label="Close"></button>
-        </div>
         <div class="om-panel"></div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- build header dynamically with setTitle helper
- collapse panel via close button and body class persistence
- add keyboard shortcuts to toggle panel and activate rail features

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43a7f93b883299b19503a85f5901b