### PR TITLE
feat(ui): pad feature panel content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The side panel UI is written in TypeScript. It presents a fixed rail on the righ
 - **Ctrl+Alt+DigitN** focuses and activates the Nth feature in the rail.
 
 ## Styling
-Core styles provide a dark theme with system UI fonts, an icon rail, and a collapsible panel. Components animate with 180ms transitions and include focus rings for accessibility.
+Core styles provide a dark theme with system UI fonts, an icon rail, and a collapsible panel. Components animate with 180ms transitions and include focus rings for accessibility. Feature iframes mount inside a padded `.om-panel__host` so content doesn't touch the panel edges.
 
 ## Rail Icons
 The rail now uses semantic toolbar and button elements. Each icon button exposes a native tooltip and ARIA label, and the active

--- a/src/ui/loader.js
+++ b/src/ui/loader.js
@@ -4,7 +4,10 @@ export function loadFeature(panel, feature) {
   panel.innerHTML = ''
   const url = chrome.runtime.getURL(`src/features/${feature.id}/${feature.entry.html}`)
   const iframe = createSandboxedIframe(url)
-  panel.appendChild(iframe)
+  const host = document.createElement('div')
+  host.className = 'om-panel__host'
+  host.appendChild(iframe)
+  panel.appendChild(host)
   const ev = new CustomEvent('omora:feature-activated', { detail: { id: feature.id, name: feature.name } })
   document.dispatchEvent(ev)
 }

--- a/src/ui/loader.ts
+++ b/src/ui/loader.ts
@@ -5,7 +5,10 @@ export function loadFeature(panel: HTMLDivElement, feature: Feature) {
   panel.innerHTML = ''
   const url = chrome.runtime.getURL(`src/features/${feature.id}/${feature.entry.html}`)
   const iframe = createSandboxedIframe(url)
-  panel.appendChild(iframe)
+  const host = document.createElement('div')
+  host.className = 'om-panel__host'
+  host.appendChild(iframe)
+  panel.appendChild(host)
   const ev = new CustomEvent('omora:feature-activated', { detail: { id: feature.id, name: feature.name } })
   document.dispatchEvent(ev)
 }

--- a/styles/core.css
+++ b/styles/core.css
@@ -140,10 +140,18 @@ body {
   overflow: hidden;
 }
 
+.om-panel__host {
+  width: 100%;
+  height: 100%;
+  padding: var(--om-space-3, 0.75rem);
+  box-sizing: border-box;
+}
+
 .om-panel iframe {
   width: 100%;
   height: 100%;
   border: 0;
+  display: block;
 }
 
 body.om-collapsed .om-shell {


### PR DESCRIPTION
## Summary
- wrap feature iframes in `.om-panel__host` to provide consistent inner padding
- mount feature iframes inside the padded host
- document padded host container in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43bdc2a6c83298691b7ca349a1a28