### PR TITLE
feat: open side panel on extension click

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Omora Chrome extension.
 The side panel UI is written in TypeScript. It presents a fixed rail on the right and a content shell on the left. A dynamic header is created in code with an `#om-title` span and `#om-close` button. Clicking close collapses the shell to leave only the rail visible and the collapsed state persists in `chrome.storage.local`.
 
 ### Keyboard Shortcuts
+- Left-click the Omora extension icon to open the panel.
 - **Ctrl+Shift+O** toggles the panel.
 - **Ctrl+Alt+DigitN** focuses and activates the Nth feature in the rail.
 

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -3,3 +3,7 @@ chrome.runtime.onInstalled.addListener(() => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
+
+chrome.action.onClicked.addListener(async (tab) => {
+  await chrome.sidePanel.open({ windowId: tab.windowId });
+});


### PR DESCRIPTION
## Summary
- open the side panel when the extension icon is left-clicked
- document icon click behavior in the README

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43d1c9cf48329b1f3c9cc25e52830