### PR TITLE
feat: add color picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ Core styles provide a dark theme with system UI fonts, an icon rail, and a colla
 ## Rail Icons
 The rail now uses semantic toolbar and button elements. Each icon button exposes a native tooltip and ARIA label, and the active
 icon is highlighted with a subtle accent background and left border glow.
+
+## Color Picker
+A dark themed color picker offers a saturation/value canvas, hue and alpha sliders, HEX and RGBA inputs, a preview swatch, and copyable RGBA, HEX, HSV, and CMYK values. The pipette button uses the EyeDropper API when available.

--- a/src/features/colorpicker/mainColorPicker.html
+++ b/src/features/colorpicker/mainColorPicker.html
@@ -1,11 +1,53 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <title>Color Picker</title>
-  </head>
-  <body>
-    <div id="color-picker">Color picker feature</div>
-    <script type="module" src="./mainColorPicker.js"></script>
-  </body>
+<head>
+<meta charset="utf-8">
+<title>Color Picker</title>
+<style>
+:root{--cp-bg:#1a1a1a;--cp-fg:#f5f5f5;--cp-border:#333;--cp-radius:4px;--cp-accent:#676cba;--cp-transition:.18s;--cp-check:#666;--cp-check2:#777}
+html,body{margin:0;height:100%;background:var(--cp-bg);color:var(--cp-fg);font:13px/1.4 system-ui}
+.cp-root{display:grid;grid-template-columns:auto 1fr;grid-template-areas:"canvas canvas""tools tools""hex hex""rgb rgb""swatch out";gap:8px;padding:8px}
+.cp-canvaswrap{grid-area:canvas;position:relative;width:300px;aspect-ratio:16/13}
+#cp-canvas{width:100%;height:100%;border-radius:var(--cp-radius);cursor:crosshair}
+.cp-tools{grid-area:tools;display:flex;align-items:center;gap:8px}
+button,input{background:#2a2a2a;color:var(--cp-fg);border:1px solid var(--cp-border);border-radius:var(--cp-radius);padding:4px;transition:var(--cp-transition)}
+button:hover,input:hover{border-color:var(--cp-accent)}
+button:active{background:#3a3a3a}
+button:focus-visible,input:focus-visible{outline:2px solid var(--cp-accent);outline-offset:2px}
+#cp-pipette{display:flex;align-items:center;justify-content:center;width:32px;height:32px;padding:0}
+#cp-hue,#cp-alpha{flex:1;height:8px;padding:0}
+#cp-hue::-webkit-slider-thumb,#cp-alpha::-webkit-slider-thumb{appearance:none;width:14px;height:14px;border-radius:50%;background:var(--cp-fg);border:1px solid var(--cp-border)}
+#cp-hue{background:linear-gradient(90deg,red,#ff0,#0f0,#0ff,#00f,#f0f,red);border:none}
+#cp-alpha{background-image:linear-gradient(90deg,rgba(103,108,186,0),rgba(103,108,186,1)),repeating-conic-gradient(var(--cp-check) 0% 25%,var(--cp-check2) 0% 50%);background-size:100% 100%,8px 8px;border:none}
+.cp-hexrow{grid-area:hex;display:flex;align-items:center;gap:8px}
+.cp-hexrow label{width:32px}
+.cp-rgbrow{grid-area:rgb;display:flex;gap:8px}
+.cp-rgbrow input{width:0;flex:1}
+.cp-out{grid-area:out;list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:4px}
+.cp-out li{display:flex;justify-content:space-between;gap:8px;align-items:center}
+.cp-out span{font-family:monospace}
+.cp-copy{width:24px;height:24px;display:flex;align-items:center;justify-content:center;padding:0}
+.cp-swatch{grid-area:swatch;width:96px;height:96px;border-radius:var(--cp-radius);border:1px solid var(--cp-border);background:#676cba}
+</style>
+</head>
+<body>
+<div class="cp-root">
+<div class="cp-canvaswrap"><canvas id="cp-canvas"></canvas></div>
+<div class="cp-tools">
+<button id="cp-pipette" aria-label="Pick"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 22l1-1 8-8"/><path d="M4 20l-2 2"/><path d="M15 3l6 6-11 11H4v-6z"/></svg></button>
+<input id="cp-hue" type="range" min="0" max="360" value="0">
+<input id="cp-alpha" type="range" min="0" max="100" value="100">
+</div>
+<div class="cp-hexrow"><label for="cp-hex">HEX</label><input id="cp-hex" maxlength="7"></div>
+<div class="cp-rgbrow"><input id="cp-r" type="number" min="0" max="255"><input id="cp-g" type="number" min="0" max="255"><input id="cp-b" type="number" min="0" max="255"><input id="cp-a" type="number" min="0" max="100"></div>
+<ul class="cp-out">
+<li><span class="cp-out-rgba"></span><button class="cp-copy" data-copy="rgba"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></li>
+<li><span class="cp-out-hex"></span><button class="cp-copy" data-copy="hex"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></li>
+<li><span class="cp-out-hsv"></span><button class="cp-copy" data-copy="hsv"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></li>
+<li><span class="cp-out-cmyk"></span><button class="cp-copy" data-copy="cmyk"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg></button></li>
+</ul>
+<div class="cp-swatch"></div>
+</div>
+<script type="module" src="./mainColorPicker.js"></script>
+</body>
 </html>

--- a/src/features/colorpicker/mainColorPicker.js
+++ b/src/features/colorpicker/mainColorPicker.js
@@ -1,19 +1,50 @@
-export function onMount(ctx) {
-  
-}
-
-export function onActivate(payload) {
-  
-}
-
-export function onDeactivate() {
-  
-}
-
-export function onMessage(msg, ctx) {
-  
-}
-
-export function onUnmount() {
-  
-}
+const canvas=document.getElementById('cp-canvas')
+const ctx=canvas.getContext('2d')
+const pipette=document.getElementById('cp-pipette')
+const hue=document.getElementById('cp-hue')
+const alpha=document.getElementById('cp-alpha')
+const hex=document.getElementById('cp-hex')
+const rIn=document.getElementById('cp-r')
+const gIn=document.getElementById('cp-g')
+const bIn=document.getElementById('cp-b')
+const aIn=document.getElementById('cp-a')
+const swatch=document.querySelector('.cp-swatch')
+const outRgba=document.querySelector('.cp-out-rgba')
+const outHex=document.querySelector('.cp-out-hex')
+const outHsv=document.querySelector('.cp-out-hsv')
+const outCmyk=document.querySelector('.cp-out-cmyk')
+const state={h:0,s:0,v:0,a:100}
+const dpr=window.devicePixelRatio||1
+function clamp(n,min,max){return Math.min(max,Math.max(min,n))}
+function hsvToRgb(h,s,v){s/=100;v/=100;h/=60;const i=Math.floor(h);const f=h-i;const p=v*(1-s);const q=v*(1-s*f);const t=v*(1-s*(1-f));let r,g,b;switch(i%6){case 0:r=v;g=t;b=p;break;case 1:r=q;g=v;b=p;break;case 2:r=p;g=v;b=t;break;case 3:r=p;g=q;b=v;break;case 4:r=t;g=p;b=v;break;default:r=v;g=p;b=q}return{r:Math.round(r*255),g:Math.round(g*255),b:Math.round(b*255)}}
+function rgbToHsv(r,g,b){r/=255;g/=255;b/=255;const max=Math.max(r,g,b);const min=Math.min(r,g,b);const d=max-min;let h=0;if(d){switch(max){case r:h=(g-b)/d+(g<b?6:0);break;case g:h=(b-r)/d+2;break;case b:h=(r-g)/d+4}h*=60}const s=max?d/max:0;const v=max;return{h:h,s:s*100,v:v*100}}
+function rgbToHex(r,g,b){const t=n=>n.toString(16).padStart(2,'0');return`#${t(r)}${t(g)}${t(b)}`}
+function hexToRgb(str){str=str.replace('#','');if(str.length===3)str=str.split('').map(c=>c+c).join('');if(!/^[0-9a-fA-F]{6}$/.test(str))return null;const n=parseInt(str,16);return{r:(n>>16)&255,g:(n>>8)&255,b:n&255}}
+function rgbToCmyk(r,g,b){const c=1-r/255;const m=1-g/255;const y=1-b/255;const k=Math.min(c,m,y);const c1=(c-k)/(1-k)||0;const m1=(m-k)/(1-k)||0;const y1=(y-k)/(1-k)||0;return{c:Math.round(c1*100),m:Math.round(m1*100),y:Math.round(y1*100),k:Math.round(k*100)}}
+function alphaStr(a){const v=a/100;return v%1?Number(v.toFixed(2)):v}
+function updateAlphaBg(r,g,b){alpha.style.backgroundImage=`linear-gradient(90deg,rgba(${r},${g},${b},0),rgba(${r},${g},${b},1)),repeating-conic-gradient(#666 0% 25%,#777 0% 50%)`;alpha.style.backgroundSize='100% 100%,8px 8px'}
+function renderCanvas(){const rect=canvas.getBoundingClientRect();const w=rect.width*dpr;const h=rect.height*dpr;if(canvas.width!==w||canvas.height!==h){canvas.width=w;canvas.height=h}const base=hsvToRgb(state.h,100,100);ctx.fillStyle=`rgb(${base.r},${base.g},${base.b})`;ctx.fillRect(0,0,w,h);const g1=ctx.createLinearGradient(0,0,w,0);g1.addColorStop(0,'#fff');g1.addColorStop(1,'rgba(255,255,255,0)');ctx.fillStyle=g1;ctx.fillRect(0,0,w,h);const g2=ctx.createLinearGradient(0,0,0,h);g2.addColorStop(0,'rgba(0,0,0,0)');g2.addColorStop(1,'#000');ctx.fillStyle=g2;ctx.fillRect(0,0,w,h);const x=state.s/100*w;const y=(1-state.v/100)*h;ctx.lineWidth=2*dpr;ctx.strokeStyle='#000';ctx.beginPath();ctx.arc(x,y,6*dpr,0,Math.PI*2);ctx.stroke();ctx.lineWidth=1*dpr;ctx.strokeStyle='#fff';ctx.beginPath();ctx.arc(x,y,6*dpr,0,Math.PI*2);ctx.stroke()}
+function sync(){const rgb=hsvToRgb(state.h,state.s,state.v);hue.value=state.h;alpha.value=state.a;rIn.value=rgb.r;gIn.value=rgb.g;bIn.value=rgb.b;aIn.value=state.a;hex.value=rgbToHex(rgb.r,rgb.g,rgb.b);swatch.style.background=`rgba(${rgb.r},${rgb.g},${rgb.b},${state.a/100})`;updateAlphaBg(rgb.r,rgb.g,rgb.b);outRgba.textContent=`rgba(${rgb.r},${rgb.g},${rgb.b},${alphaStr(state.a)})`;outHex.textContent=rgbToHex(rgb.r,rgb.g,rgb.b);outHsv.textContent=`hsv(${Math.round(state.h)},${Math.round(state.s)}%,${Math.round(state.v)}%)`;const cmyk=rgbToCmyk(rgb.r,rgb.g,rgb.b);outCmyk.textContent=`cmyk(${cmyk.c},${cmyk.m},${cmyk.y},${cmyk.k})`;renderCanvas()}
+function setFromRGB(r,g,b,a){const hsv=rgbToHsv(r,g,b);state.h=hsv.h;state.s=hsv.s;state.v=hsv.v;state.a=a;sync()}
+function setFromHex(str){const rgb=hexToRgb(str);if(rgb)setFromRGB(rgb.r,rgb.g,rgb.b,state.a)}
+function setFromHSV(h,s,v){state.h=h;state.s=s;state.v=v;sync()}
+let prevHex=''
+function commitHex(){const v=hex.value.trim();const rgb=hexToRgb(v);if(rgb){setFromRGB(rgb.r,rgb.g,rgb.b,state.a);prevHex=hex.value}else hex.value=prevHex}
+hex.addEventListener('focus',()=>prevHex=hex.value)
+hex.addEventListener('keydown',e=>{if(e.key==='Enter'){commitHex();hex.blur()}})
+hex.addEventListener('blur',commitHex)
+function commitRgb(){const r=clamp(+rIn.value||0,0,255);const g=clamp(+gIn.value||0,0,255);const b=clamp(+bIn.value||0,0,255);const a=clamp(+aIn.value||0,0,100);setFromRGB(r,g,b,a)}
+rIn.addEventListener('change',commitRgb)
+gIn.addEventListener('change',commitRgb)
+bIn.addEventListener('change',commitRgb)
+aIn.addEventListener('change',commitRgb)
+hue.addEventListener('input',e=>{state.h=+e.target.value;sync()})
+alpha.addEventListener('input',e=>{state.a=+e.target.value;sync()})
+function canvasPoint(e){const rect=canvas.getBoundingClientRect();const x=e.clientX-rect.left;const y=e.clientY-rect.top;const s=clamp(x/rect.width*100,0,100);const v=clamp(100-y/rect.height*100,0,100);setFromHSV(state.h,s,v)}
+canvas.addEventListener('pointerdown',e=>{canvas.setPointerCapture(e.pointerId);canvasPoint(e);canvas.addEventListener('pointermove',canvasPoint)})
+canvas.addEventListener('pointerup',e=>{canvas.releasePointerCapture(e.pointerId);canvas.removeEventListener('pointermove',canvasPoint)})
+document.querySelectorAll('.cp-copy').forEach(btn=>btn.addEventListener('click',()=>{const t=btn.dataset.copy;let text='';if(t==='rgba')text=outRgba.textContent;else if(t==='hex')text=outHex.textContent;else if(t==='hsv')text=outHsv.textContent;else text=outCmyk.textContent;navigator.clipboard.writeText(text)}))
+if(!('EyeDropper'in window))pipette.disabled=true
+pipette.addEventListener('click',async()=>{if(pipette.disabled)return;document.body.style.cursor='crosshair';try{const d=await new EyeDropper().open();setFromHex(d.sRGBHex)}catch{}document.body.style.cursor=''})
+new ResizeObserver(renderCanvas).observe(document.querySelector('.cp-canvaswrap'))
+setFromHex('#676cba')


### PR DESCRIPTION
## Summary
- build dark color picker UI with hue, alpha, and pipette tools
- implement conversions between HEX, RGB, HSV, and CMYK with copy buttons
- document the color picker feature in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43e41d1cc83298af7dfb4ace4c6c9