### PR TITLE
Add in-page sidebar and side panel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Omora Chrome extension.
 
+## ISidebar
+Each page displays a draggable rail on the right edge with buttons for Notes and Color Picker. The rail appears only in browsers that support the side panel API. Choosing a button opens the Omora side panel for that feature.
+
 ## Development
 The side panel UI is written in TypeScript. It presents a fixed rail on the right and a content shell on the left. A dynamic header is created in code with an `#om-title` span and `#om-close` button. Clicking close collapses the shell to leave only the rail visible and the collapsed state persists in `chrome.storage.local`.
 
@@ -16,6 +19,9 @@ Core styles provide a dark theme with system UI fonts, an icon rail, and a colla
 ## Rail Icons
 The rail now uses semantic toolbar and button elements. Each icon button exposes a native tooltip and ARIA label, and the active
 icon is highlighted with a subtle accent background and left border glow.
+
+## Notes
+A quick scratchpad for jotting down thoughts while browsing.
 
 ## Color Picker
 A dark themed color picker offers a saturation/value canvas, hue and alpha sliders, HEX and RGBA inputs, a preview swatch, and copyable RGBA, HEX, HSV, and CMYK values. The pipette button uses the EyeDropper API when available.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,23 @@
+chrome.runtime.onInstalled.addListener(() => {
+  if (!chrome.sidePanel) return
+  chrome.sidePanel.setOptions({ path: 'sidepanel.html' })
+  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false })
+})
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg && msg.type === 'omora:has-sidepanel') {
+    sendResponse({ ok: !!chrome.sidePanel })
+    return
+  }
+  if (msg && msg.type === 'omora:open-esidebar' && sender.tab && sender.tab.id && chrome.sidePanel) {
+    const tabId = sender.tab.id
+    const key = 'omora:feature:' + tabId
+    chrome.storage.session.set({ [key]: msg.feature })
+    chrome.sidePanel.setOptions({ tabId, path: 'sidepanel.html', enabled: true })
+    chrome.sidePanel.open({ tabId })
+  }
+})
+
+chrome.tabs.onRemoved.addListener(tabId => {
+  chrome.storage.session.remove('omora:feature:' + tabId)
+})

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,49 @@
+chrome.runtime.sendMessage({ type: 'omora:has-sidepanel' }, res => {
+  if (!res || !res.ok) return
+  const key = 'omora:offset:' + location.origin
+  const host = document.createElement('div')
+  const root = host.attachShadow({ mode: 'open' })
+  const style = document.createElement('style')
+  style.textContent = '#rail{position:fixed!important;right:0;width:48px;background:#111;display:flex;flex-direction:column;z-index:2147483647}button{width:48px;height:48px;background:none;border:0;color:#fff;cursor:pointer}'
+  const rail = document.createElement('div')
+  rail.id = 'rail'
+  ;[
+    { id: 'notes', label: 'N' },
+    { id: 'colorpicker', label: 'C' }
+  ].forEach(({ id, label }) => {
+    const btn = document.createElement('button')
+    btn.textContent = label
+    btn.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'omora:open-esidebar', feature: id })
+    })
+    rail.appendChild(btn)
+  })
+  root.appendChild(style)
+  root.appendChild(rail)
+  document.documentElement.appendChild(host)
+  chrome.storage.local.get(key).then(r => {
+    const top = r[key]
+    const h = window.innerHeight || document.documentElement.clientHeight
+    rail.style.top = (typeof top === 'number' ? top : h * 0.3) + 'px'
+  })
+  let startY
+  let startTop
+  rail.addEventListener('pointerdown', e => {
+    if (e.target !== rail) return
+    startY = e.clientY
+    startTop = parseInt(rail.style.top, 10)
+    const move = ev => {
+      const t = startTop + ev.clientY - startY
+      rail.style.top = (t < 0 ? 0 : t) + 'px'
+    }
+    const up = () => {
+      document.removeEventListener('pointermove', move)
+      document.removeEventListener('pointerup', up)
+      const val = parseInt(rail.style.top, 10)
+      chrome.storage.local.set({ [key]: val })
+    }
+    document.addEventListener('pointermove', move)
+    document.addEventListener('pointerup', up)
+  })
+})
+

--- a/manifest.json
+++ b/manifest.json
@@ -3,13 +3,22 @@
   "description": "Omora Chrome Extension",
   "version": "0.1.0",
   "manifest_version": 3,
-  "permissions": ["sidePanel", "storage", "scripting", "activeTab"],
+  "permissions": ["sidePanel", "activeTab", "scripting", "storage"],
+  "host_permissions": ["<all_urls>"],
   "background": {
-    "service_worker": "src/background/index.js"
+    "service_worker": "background.js"
   },
   "side_panel": {
-    "default_path": "src/ui/index.html"
+    "default_path": "sidepanel.html"
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "action": {},
   "web_accessible_resources": [
     {
       "resources": ["src/features/*/*.html", "src/features/*/*.js", "src/features/*/*.png", "src/features/*/*.json"],

--- a/panelBootstrap.js
+++ b/panelBootstrap.js
@@ -1,0 +1,19 @@
+async function init() {
+  const contexts = await chrome.runtime.getContexts({ contextTypes: ['SIDE_PANEL'] })
+  const tabId = contexts[0] && contexts[0].tabId
+  if (!tabId) return
+  const key = 'omora:feature:' + tabId
+  const data = await chrome.storage.session.get(key)
+  const feature = data[key]
+  if (!feature) return
+  const select = () => {
+    const btn = document.querySelector(`.om-rail__icon[data-id="${feature}"]`)
+    if (btn) {
+      btn.click()
+    } else {
+      requestAnimationFrame(select)
+    }
+  }
+  select()
+}
+document.addEventListener('DOMContentLoaded', init)

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Omora Panel</title>
+<link rel="stylesheet" href="styles/tokens.css">
+<link rel="stylesheet" href="styles/core.css">
+</head>
+<body>
+<div id="app">
+<div class="om-rail"></div>
+<div class="om-shell">
+<div class="om-panel"></div>
+</div>
+</div>
+<script type="module" src="src/ui/app.js"></script>
+<script src="panelBootstrap.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Inject draggable in-page sidebar with Notes and Color Picker buttons
- Open Chrome side panel from background and restore feature per tab
- Bootstrap side panel to activate the stored feature on load
- Only show sidebar when the side panel API is available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a583637c748329847796a34902fd55